### PR TITLE
Add Timber logging library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.kotlin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -56,6 +57,7 @@ dependencies {
     implementation(libs.shizuku.provider)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.timber)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,18 @@ android {
         compose = true
         buildConfig = true
     }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            all {
+                // Force a neutral locale for the test JVM. On a Turkish (tr_TR)
+                // default locale, "Linux".lowercase() yields "lınux" (dotless i),
+                // which breaks native library name resolution in Conscrypt/Robolectric.
+                it.systemProperty("user.language", "en")
+                it.systemProperty("user.country", "US")
+            }
+        }
+    }
 }
 
 dependencies {
@@ -59,6 +71,12 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.timber)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.junit)
+    testImplementation(libs.androidx.test.core.ktx)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/io/github/warleysr/dechainer/DechainerApplication.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/DechainerApplication.kt
@@ -2,6 +2,7 @@ package io.github.warleysr.dechainer
 
 import android.app.Application
 import io.github.warleysr.dechainer.security.SecurityManager
+import timber.log.Timber
 
 class DechainerApplication : Application() {
 
@@ -17,5 +18,9 @@ class DechainerApplication : Application() {
         super.onCreate()
 
         instance = this
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ appcompat = "1.7.0"
 composeBom = "2025.12.01"
 materialIconsExtended = "1.7.8"
 shizuku = "13.1.5"
+timber = "5.0.1"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -32,6 +33,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,11 @@ composeBom = "2025.12.01"
 materialIconsExtended = "1.7.8"
 shizuku = "13.1.5"
 timber = "5.0.1"
+robolectric = "4.16.1"
+kotest = "5.9.1"
+mockk = "1.14.2"
+coroutinesTest = "1.9.0"
+androidxTestCore = "1.7.0"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -34,6 +39,11 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Integrate Timber as the logging infrastructure without using it for any logging yet. A DebugTree is planted only in debug builds via BuildConfig.DEBUG, so release builds keep logging as a no-op until an explicit tree is added.

- Add timber 5.0.1 to the version catalog and app dependencies
- Enable BuildConfig generation (needed for the DEBUG flag under AGP 8.x)
- Plant Timber.DebugTree() in DechainerApplication for debug builds