### PR TITLE
Logging testing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/java/io/github/warleysr/dechainer/browser/BrowserRestrictionsManagerTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/browser/BrowserRestrictionsManagerTest.kt
@@ -1,0 +1,96 @@
+package io.github.warleysr.dechainer.browser
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.RestrictionEntry
+import android.content.RestrictionsManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.BrowserRestrictionsManager
+import io.github.warleysr.dechainer.DechainerDeviceAdminReceiver
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.installBrowser
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Exercises [BrowserRestrictionsManager] against a Robolectric package manager and a mockk
+ * [RestrictionsManager]: `getPossibleBrowsers` collapses the same browser resolved by all three of its
+ * intent queries into one entry and drops our own package, `isBrowser` mirrors that membership,
+ * `supportsRestrictions` requires both `URLBlocklist` and `ForceGoogleSafeSearch` in the browser's
+ * manifest restrictions, and `applyRestrictions` returns without touching any browser when no
+ * `blocked_lists_json` is saved.
+ */
+@RunWith(AndroidJUnit4::class)
+class BrowserRestrictionsManagerTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val manager = BrowserRestrictionsManager(context)
+    private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+    private val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+
+    private fun managerReporting(entries: List<RestrictionEntry>): BrowserRestrictionsManager {
+        val restrictionsManager = mockk<RestrictionsManager>()
+        every { restrictionsManager.getManifestRestrictions(any()) } returns entries
+        val mockContext = mockk<Context>()
+        every { mockContext.getSystemService(Context.RESTRICTIONS_SERVICE) } returns restrictionsManager
+        return BrowserRestrictionsManager(mockContext)
+    }
+
+    @Test
+    fun `getPossibleBrowsers deduplicates the three intent queries and drops our own package`() {
+        installBrowser("com.fake.browser")
+        installBrowser("com.other.browser")
+        installBrowser(context.packageName)
+
+        val browsers = manager.getPossibleBrowsers().map { it.activityInfo.packageName }
+
+        browsers shouldContainExactlyInAnyOrder listOf("com.fake.browser", "com.other.browser")
+    }
+
+    @Test
+    fun `isBrowser is true for an installed browser and false otherwise`() {
+        installBrowser("com.fake.browser")
+
+        manager.isBrowser("com.fake.browser") shouldBe true
+        manager.isBrowser("com.not.abrowser") shouldBe false
+    }
+
+    @Test
+    fun `supportsRestrictions is true when the browser declares both required keys`() {
+        val entries = listOf(
+            RestrictionEntry(RestrictionEntry.TYPE_STRING, "URLBlocklist"),
+            RestrictionEntry(RestrictionEntry.TYPE_STRING, "ForceGoogleSafeSearch"),
+        )
+
+        managerReporting(entries).supportsRestrictions("com.fake.browser") shouldBe true
+    }
+
+    @Test
+    fun `supportsRestrictions is false when a required key is missing`() {
+        val entries = listOf(RestrictionEntry(RestrictionEntry.TYPE_STRING, "URLBlocklist"))
+
+        managerReporting(entries).supportsRestrictions("com.fake.browser") shouldBe false
+    }
+
+    @Test
+    fun `applyRestrictions leaves installed browsers untouched when no blocklist json is saved`() {
+        installBrowser("com.fake.browser")
+        shadowOf(dpm).setDeviceOwner(admin)
+
+        shouldNotThrowAny { manager.applyRestrictions() }
+
+        dpm.getApplicationRestrictions(admin, "com.fake.browser").isEmpty shouldBe true
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/contract/ManifestContractTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/contract/ManifestContractTest.kt
@@ -1,0 +1,152 @@
+package io.github.warleysr.dechainer.contract
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.DechainerAccessibilityService
+import io.github.warleysr.dechainer.DechainerDeviceAdminReceiver
+import io.github.warleysr.dechainer.activities.BlockedWordActivity
+import io.github.warleysr.dechainer.activities.MainActivity
+import io.github.warleysr.dechainer.activities.ReopeningLimitActivity
+import io.github.warleysr.dechainer.activities.TimeUpActivity
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.xmlpull.v1.XmlPullParser
+
+/**
+ * Each test reads the app's own merged manifest through the real [PackageManager] and pins it against
+ * the class references the code depends on, so a component that gets moved, renamed or stripped of its
+ * permission without the manifest following turns this test red. The accessibility service, the
+ * device-admin receiver and the launcher activity each carry the permission or intent-filter the
+ * platform needs to bind them, and the three block screens the service launches must stay declared or
+ * blocking silently fails to show. Nothing here reaches into class internals.
+ */
+@RunWith(AndroidJUnit4::class)
+class ManifestContractTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val packageManager = context.packageManager
+    private val packageName = context.packageName
+
+    @Test
+    fun `the accessibility service is declared with the bind-accessibility-service permission`() {
+        val service = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_SERVICES)
+            .services
+            ?.firstOrNull { it.name == DechainerAccessibilityService::class.java.name }
+            .shouldNotBeNull()
+
+        service.permission shouldBe "android.permission.BIND_ACCESSIBILITY_SERVICE"
+        service.exported.shouldBeFalse()
+    }
+
+    @Test
+    fun `the accessibility service is discoverable by its intent and carries its config meta-data`() {
+        val intent = Intent("android.accessibilityservice.AccessibilityService")
+        packageManager.queryIntentServices(intent, 0)
+            .any { it.serviceInfo.name == DechainerAccessibilityService::class.java.name }
+            .shouldBeTrue()
+
+        val service = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_SERVICES or PackageManager.GET_META_DATA)
+            .services
+            ?.firstOrNull { it.name == DechainerAccessibilityService::class.java.name }
+            .shouldNotBeNull()
+
+        val meta = service.metaData.shouldNotBeNull()
+        meta.containsKey("android.accessibilityservice").shouldBeTrue()
+    }
+
+    @Test
+    fun `the device admin receiver is declared exported with the bind-device-admin permission`() {
+        val receiver = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_RECEIVERS)
+            .receivers
+            ?.firstOrNull { it.name == DechainerDeviceAdminReceiver::class.java.name }
+            .shouldNotBeNull()
+
+        receiver.permission shouldBe "android.permission.BIND_DEVICE_ADMIN"
+        receiver.exported.shouldBeTrue()
+    }
+
+    @Test
+    fun `the device admin receiver responds to the device-admin-enabled action and carries its policy meta-data`() {
+        val intent = Intent("android.app.action.DEVICE_ADMIN_ENABLED")
+        packageManager.queryBroadcastReceivers(intent, 0)
+            .any { it.activityInfo.name == DechainerDeviceAdminReceiver::class.java.name }
+            .shouldBeTrue()
+
+        val receiver = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_RECEIVERS or PackageManager.GET_META_DATA)
+            .receivers
+            ?.firstOrNull { it.name == DechainerDeviceAdminReceiver::class.java.name }
+            .shouldNotBeNull()
+
+        val meta = receiver.metaData.shouldNotBeNull()
+        meta.containsKey("android.app.device_admin").shouldBeTrue()
+    }
+
+    @Test
+    fun `MainActivity is the launcher activity`() {
+        val launch = packageManager.getLaunchIntentForPackage(packageName).shouldNotBeNull()
+
+        launch.component?.className shouldBe MainActivity::class.java.name
+    }
+
+    @Test
+    fun `the launcher and all block activities are declared`() {
+        val declared = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_ACTIVITIES)
+            .activities
+            ?.map { it.name }
+            .orEmpty()
+
+        declared shouldContainAll listOf(
+            MainActivity::class.java.name,
+            TimeUpActivity::class.java.name,
+            ReopeningLimitActivity::class.java.name,
+            BlockedWordActivity::class.java.name,
+        )
+    }
+
+    @Test
+    fun `the accessibility settings activity points to a declared activity`() {
+        val service = packageManager
+            .getPackageInfo(packageName, PackageManager.GET_SERVICES or PackageManager.GET_META_DATA)
+            .services
+            ?.firstOrNull { it.name == DechainerAccessibilityService::class.java.name }
+            .shouldNotBeNull()
+
+        val configResId = service.metaData.shouldNotBeNull().getInt("android.accessibilityservice")
+        val settingsActivity = readSettingsActivity(configResId).shouldNotBeNull()
+
+        packageManager.getActivityInfo(ComponentName(packageName, settingsActivity), 0)
+    }
+
+    private fun readSettingsActivity(configResId: Int): String? {
+        val androidNamespace = "http://schemas.android.com/apk/res/android"
+        val parser = context.resources.getXml(configResId)
+        var event = parser.eventType
+        while (event != XmlPullParser.END_DOCUMENT) {
+            if (event == XmlPullParser.START_TAG && parser.name == "accessibility-service") {
+                return parser.getAttributeValue(androidNamespace, "settingsActivity")
+            }
+            event = parser.next()
+        }
+        return null
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/contract/PreferencesContractTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/contract/PreferencesContractTest.kt
@@ -1,0 +1,139 @@
+package io.github.warleysr.dechainer.contract
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.security.SecurityManager
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.json.JSONArray
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Each test drives the real writer of one persistence contract and then reads the value straight out
+ * of the `SharedPreferences` file with the exact raw name, key and typed getter the reading side uses,
+ * so a writer whose literal or type drifts away from its reader turns this test red. The usage-stats
+ * row runs the reverse way — the service is the writer there — so a raw long is written and read back
+ * through the real view model. The `security_prefs` / `shuffle_keyboard` row is written and read only
+ * from Compose UI and is left to the Compose test. Nothing here reaches into class
+ * internals.
+ */
+@RunWith(AndroidJUnit4::class)
+class PreferencesContractTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val targetPackage = "com.example.socialapp"
+
+    @Test
+    fun `blocked words are persisted as a string set under the key the service reads`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.updateWords("kumar\nbahis")
+
+        prefs("blocked_words_prefs").getStringSet("blocked_words", emptySet()) shouldBe
+            setOf("kumar", "bahis")
+    }
+
+    @Test
+    fun `target packages are persisted as a string set under the key the service reads`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.toggleAppSelection(targetPackage)
+
+        prefs("blocked_words_prefs").getStringSet("target_packages", emptySet()) shouldBe
+            setOf(targetPackage)
+    }
+
+    @Test
+    fun `passive words are persisted under the per-package prefixed key as a string set`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.updatePassiveWords(targetPackage, "kumar\nbahis")
+
+        prefs("blocked_words_prefs").getStringSet("passive_words_$targetPackage", emptySet()) shouldBe
+            setOf("kumar", "bahis")
+    }
+
+    @Test
+    fun `clearing passive words removes the per-package key`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+        viewModel.updatePassiveWords(targetPackage, "kumar")
+
+        viewModel.updatePassiveWords(targetPackage, "")
+
+        prefs("blocked_words_prefs").contains("passive_words_$targetPackage") shouldBe false
+    }
+
+    @Test
+    fun `blocked activities are persisted as a string set under the key the service reads`() {
+        val viewModel = Fixtures.activityBlockerViewModel()
+
+        viewModel.addBlockedActivity("com.example.app.SettingsActivity")
+
+        prefs("activity_blocker_prefs").getStringSet("blocked_activities", emptySet()) shouldBe
+            setOf("com.example.app.SettingsActivity")
+    }
+
+    @Test
+    fun `an app time limit is persisted as an int under the package-named key`() {
+        val viewModel = Fixtures.appsViewModel()
+
+        viewModel.setAppTimeLimit(targetPackage, 30)
+
+        prefs("app_limits").getInt(targetPackage, 0) shouldBe 30
+    }
+
+    @Test
+    fun `an app reopen time is persisted as an int under the package-named key`() {
+        val viewModel = Fixtures.appsViewModel()
+
+        viewModel.setAppReopenTime(targetPackage, 60)
+
+        prefs("reopen_times").getInt(targetPackage, 0) shouldBe 60
+    }
+
+    @Test
+    fun `usage stats written as a long are read back by the view model in millis and minutes`() {
+        prefs("internal_usage_stats").edit().putLong(targetPackage, 300_000L).commit()
+
+        val viewModel = Fixtures.appsViewModel()
+
+        viewModel.getAppUsage(targetPackage) shouldBe 300_000L
+        viewModel.getAppUsage(targetPackage, inMinutes = true) shouldBe 5L
+    }
+
+    @Test
+    fun `a browser blocklist is persisted as json under the key the manager reads with id title and sites`() {
+        val viewModel = Fixtures.browserRestrictionsViewModel()
+
+        viewModel.saveOrUpdateList("list-1", "Adult", "a.com\nb.com")
+
+        val json = prefs("browser_prefs").getString("blocked_lists_json", null).shouldNotBeNull()
+        val array = JSONArray(json)
+        array.length() shouldBe 1
+        val obj = array.getJSONObject(0)
+        obj.getString("id") shouldBe "list-1"
+        obj.getString("title") shouldBe "Adult"
+        val sites = obj.getJSONArray("sites")
+        (0 until sites.length()).map { sites.getString(it) } shouldContainExactlyInAnyOrder
+            listOf("a.com", "b.com")
+    }
+
+    @Test
+    fun `the recovery code is persisted as a string under the key SecurityManager reads`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        SecurityManager.saveRecoveryCode(context, "ABCDEFGHIJKLMNOP")
+
+        prefs("recovery_prefs").getString("recovery_code", null) shouldBe "ABCDEFGHIJKLMNOP"
+        SecurityManager.getRecoveryCode(context) shouldBe "ABCDEFGHIJKLMNOP"
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/contract/StringsParityTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/contract/StringsParityTest.kt
@@ -1,0 +1,77 @@
+package io.github.warleysr.dechainer.contract
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * A pure-JVM test that parses the `values` and `values-pt` `strings.xml` files straight off disk and
+ * checks the two locales stay in lockstep, so a translation that drops a key or garbles a format
+ * argument is caught at build time instead of crashing only in the affected language. The key check
+ * pins that both files declare the exact same set of names; the blank check pins that no value is
+ * empty; the format check pins that every shared key carries the same multiset of `%` placeholders,
+ * which is where a divergence would throw `IllegalFormatException` at runtime. Nothing here touches
+ * the Android framework.
+ */
+class StringsParityTest {
+
+    private val baseStrings = parseStrings("values")
+    private val translatedStrings = parseStrings("values-pt")
+
+    @Test
+    fun `both locales declare the same string keys`() {
+        translatedStrings.keys shouldBe baseStrings.keys
+    }
+
+    @Test
+    fun `no string value is blank in either locale`() {
+        baseStrings.filterValues { it.isBlank() }.keys shouldBe emptySet()
+        translatedStrings.filterValues { it.isBlank() }.keys shouldBe emptySet()
+    }
+
+    @Test
+    fun `format arguments match across locales for every shared key`() {
+        val mismatches = baseStrings.keys.intersect(translatedStrings.keys)
+            .mapNotNull { key ->
+                val base = formatArgs(baseStrings.getValue(key))
+                val translated = formatArgs(translatedStrings.getValue(key))
+                if (base != translated) key to (base to translated) else null
+            }
+            .toMap()
+
+        mismatches shouldBe emptyMap()
+    }
+
+    private fun formatArgs(value: String): List<String> =
+        FORMAT_ARG.findAll(value).map { it.value }.sorted().toList()
+
+    private fun parseStrings(qualifier: String): Map<String, String> {
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(resolveStringsFile(qualifier))
+        val nodes = document.getElementsByTagName("string")
+
+        val result = LinkedHashMap<String, String>()
+        for (i in 0 until nodes.length) {
+            val element = nodes.item(i) as Element
+            result[element.getAttribute("name")] = element.textContent
+        }
+        return result
+    }
+
+    private fun resolveStringsFile(qualifier: String): File {
+        val relative = "src/main/res/$qualifier/strings.xml"
+        val candidates = listOf(
+            File(System.getProperty("user.dir"), relative),
+            File(System.getProperty("user.dir"), "app/$relative"),
+        )
+        return candidates.firstOrNull { it.exists() }
+            ?: error("strings.xml not found for '$qualifier'; tried ${candidates.joinToString { it.absolutePath }}")
+    }
+
+    private companion object {
+        private val FORMAT_ARG = Regex("%(\\d+\\$)?[a-zA-Z]")
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/pipeline/ActiveWordBlockingPipelineTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/pipeline/ActiveWordBlockingPipelineTest.kt
@@ -17,9 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Vertical-slice tests for active (typed) word blocking — invariants R2 (blocking always happens)
- * and R1 (the persistence contract).
- *
  * Each test writes through the real [io.github.warleysr.dechainer.viewmodels.BlockedWordsViewModel]
  * and reads through the real [io.github.warleysr.dechainer.DechainerAccessibilityService], so the
  * only thing under test is the end-to-end behaviour.

--- a/app/src/test/java/io/github/warleysr/dechainer/security/RecoveryGateUiTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/security/RecoveryGateUiTest.kt
@@ -1,0 +1,122 @@
+package io.github.warleysr.dechainer.security
+
+import android.content.Context
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.screens.common.RecoveryConfirmDialog
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Drives the [RecoveryConfirmDialog] Compose UI under Robolectric to pin the recovery gate's R3
+ * guarantees at the UI boundary: the confirm button stays disabled until exactly sixteen letters are
+ * entered, input is sanitised to uppercase A–Z and truncated at sixteen, an incorrect code (onConfirm
+ * returning false) surfaces the error and leaves the dialog open instead of unlocking, and the shuffle
+ * keyboard always offers the next correct letter — so entry can never get stuck — while rebuilding the
+ * grid after every tap and backspace.
+ */
+@RunWith(AndroidJUnit4::class)
+class RecoveryGateUiTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val dechainerRule = DechainerTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `confirm stays disabled until sixteen letters are entered`() {
+        composeRule.setContent {
+            RecoveryConfirmDialog(onConfirm = { true }, onDismiss = {})
+        }
+
+        composeRule.onNodeWithText("Confirm").assertIsNotEnabled()
+
+        composeRule.onNode(hasSetTextAction()).performTextInput("ABCDEFGHIJKLMNO")
+        composeRule.onNodeWithText("Confirm").assertIsNotEnabled()
+
+        composeRule.onNode(hasSetTextAction()).performTextInput("P")
+        composeRule.onNodeWithText("Confirm").assertIsEnabled()
+    }
+
+    @Test
+    fun `input is sanitised to uppercase letters and truncated at sixteen`() {
+        composeRule.setContent {
+            RecoveryConfirmDialog(onConfirm = { true }, onDismiss = {})
+        }
+
+        composeRule.onNode(hasSetTextAction()).performTextInput("ab1!cD@efGHijklmnopqrstuv")
+
+        composeRule.onNode(hasSetTextAction()).assert(hasText("ABCDEFGHIJKLMNOP"))
+        composeRule.onNodeWithText("16/16").assertExists()
+    }
+
+    @Test
+    fun `an incorrect code shows the error and keeps the gate closed`() {
+        var captured: String? = null
+        composeRule.setContent {
+            RecoveryConfirmDialog(onConfirm = { captured = it; false }, onDismiss = {})
+        }
+
+        composeRule.onNode(hasSetTextAction()).performTextInput("ABCDEFGHIJKLMNOP")
+        composeRule.onNodeWithText("Confirm").performClick()
+
+        captured shouldBe "ABCDEFGHIJKLMNOP"
+        composeRule.onNodeWithText("Invalid recovery code").assertExists()
+        composeRule.onNode(hasSetTextAction()).assertExists()
+    }
+
+    @Test
+    fun `the shuffle keyboard always offers the next correct letter so entry never gets stuck`() {
+        val code = "ABCDEFGHIJKLMNOP"
+        prefs("security_prefs").edit().putBoolean("shuffle_keyboard", true).commit()
+        SecurityManager.saveRecoveryCode(context, code)
+
+        composeRule.setContent {
+            RecoveryConfirmDialog(onConfirm = { true }, onDismiss = {})
+        }
+
+        code.forEachIndexed { index, letter ->
+            composeRule.onNodeWithText("$index/16").assertExists()
+            composeRule.onNodeWithText(letter.toString()).performClick()
+        }
+
+        composeRule.onNodeWithText("16/16").assertExists()
+        composeRule.onNodeWithText("Confirm").assertIsEnabled()
+    }
+
+    @Test
+    fun `the shuffle keyboard rebuilds the grid after every tap`() {
+        val code = "ABCDEFGHIJKLMNOP"
+        prefs("security_prefs").edit().putBoolean("shuffle_keyboard", true).commit()
+        SecurityManager.saveRecoveryCode(context, code)
+
+        composeRule.setContent {
+            RecoveryConfirmDialog(onConfirm = { true }, onDismiss = {})
+        }
+
+        composeRule.onNodeWithText("0/16").assertExists()
+        composeRule.onNodeWithText("A").performClick()
+
+        composeRule.onNodeWithText("1/16").assertExists()
+        composeRule.onNodeWithText("B").performClick()
+
+        composeRule.onNodeWithText("2/16").assertExists()
+        composeRule.onNodeWithText("C").assertExists()
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/support/Fixtures.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/support/Fixtures.kt
@@ -4,6 +4,8 @@ import io.github.warleysr.dechainer.viewmodels.ActivityBlockerViewModel
 import io.github.warleysr.dechainer.viewmodels.AppsViewModel
 import io.github.warleysr.dechainer.viewmodels.BlockedWordsViewModel
 import io.github.warleysr.dechainer.viewmodels.BrowserRestrictionsViewModel
+import io.github.warleysr.dechainer.viewmodels.DeviceOwnerViewModel
+import io.github.warleysr.dechainer.viewmodels.RestrictionsViewModel
 
 /**
  * Single construction point for the app's ViewModels in tests.
@@ -20,4 +22,8 @@ object Fixtures {
     fun appsViewModel() = AppsViewModel()
 
     fun browserRestrictionsViewModel() = BrowserRestrictionsViewModel()
+
+    fun restrictionsViewModel() = RestrictionsViewModel()
+
+    fun deviceOwnerViewModel() = DeviceOwnerViewModel()
 }

--- a/app/src/test/java/io/github/warleysr/dechainer/support/PackageFixtures.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/support/PackageFixtures.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.ResolveInfo
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
@@ -12,6 +13,9 @@ import org.robolectric.Shadows.shadowOf
 /**
  * Installs fake packages into the Robolectric [org.robolectric.shadows.ShadowPackageManager] so the
  * app's `PackageManager` queries resolve them.
+ *
+ * [installApp] registers a plain package that `getInstalledApplications` returns, optionally flagged
+ * as a system app so filtering on [ApplicationInfo.FLAG_SYSTEM] can be exercised.
  *
  * [installBrowser] registers a browser that
  * [io.github.warleysr.dechainer.BrowserRestrictionsManager.getPossibleBrowsers] can find: it resolves
@@ -42,4 +46,21 @@ fun installBrowser(packageName: String, label: String = "Fake Browser") {
     listOf(browserCategory, httpView, httpsView).forEach { intent ->
         shadowPackageManager.addResolveInfoForIntent(intent, resolveInfo)
     }
+}
+
+fun installApp(packageName: String, label: String = packageName, system: Boolean = false) {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val shadowPackageManager = shadowOf(context.packageManager)
+
+    val info = ApplicationInfo().apply {
+        this.packageName = packageName
+        name = label
+        nonLocalizedLabel = label
+        flags = if (system) ApplicationInfo.FLAG_SYSTEM else 0
+    }
+    val packageInfo = PackageInfo().apply {
+        this.packageName = packageName
+        applicationInfo = info
+    }
+    shadowPackageManager.installPackage(packageInfo)
 }

--- a/app/src/test/java/io/github/warleysr/dechainer/support/ShadowDechainerDpm.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/support/ShadowDechainerDpm.kt
@@ -1,0 +1,42 @@
+package io.github.warleysr.dechainer.support
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.os.Bundle
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowDevicePolicyManager
+
+/**
+ * A [DevicePolicyManager] shadow that makes user restrictions round-trip.
+ *
+ * The stock [ShadowDevicePolicyManager] never implements `getUserRestrictions(ComponentName)` — the real
+ * framework method returns an empty `Bundle` — so nothing written by `addUserRestriction` is ever read
+ * back, and its `add`/`clearUserRestriction` route through `enforceActiveAdmin`, which throws when no
+ * active admin is registered. Both make it impossible to observe
+ * [io.github.warleysr.dechainer.viewmodels.RestrictionsViewModel]'s apply/load cycle.
+ *
+ * This shadow keeps the enabled restriction keys in its own [Bundle]: `addUserRestriction` sets a key,
+ * `clearUserRestriction` drops it, and `getUserRestrictions` returns a copy — so a test can grant a
+ * device owner, apply a draft, and read the applied state back exactly as the view model does. Register
+ * it with `@Config(shadows = [ShadowDechainerDpm::class])`; device-owner setup still uses the inherited
+ * `setDeviceOwner`.
+ */
+@Implements(DevicePolicyManager::class)
+class ShadowDechainerDpm : ShadowDevicePolicyManager() {
+
+    private val userRestrictions = Bundle()
+
+    @Implementation
+    fun getUserRestrictions(admin: ComponentName?): Bundle = Bundle(userRestrictions)
+
+    @Implementation
+    override fun addUserRestriction(admin: ComponentName?, key: String?) {
+        userRestrictions.putBoolean(key, true)
+    }
+
+    @Implementation
+    override fun clearUserRestriction(admin: ComponentName?, key: String?) {
+        userRestrictions.remove(key)
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/utils/LocaleUtilsTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/utils/LocaleUtilsTest.kt
@@ -1,0 +1,42 @@
+package io.github.warleysr.dechainer.utils
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.util.Locale
+
+/**
+ * Exercises [LocaleUtils] on both sides of its `Build.VERSION.SDK_INT` fork by running under API 30 (the
+ * AppCompatDelegate branch) and API 36 (the framework LocaleManager branch): a language set through
+ * `setLocale` reads back identically through `getLocale`, and with no application locale set `getLocale`
+ * falls back to the system default language instead of returning an empty tag.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30, 36])
+class LocaleUtilsTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `a language set through setLocale reads back through getLocale`() {
+        LocaleUtils.setLocale(context, "es")
+
+        LocaleUtils.getLocale(context) shouldBe "es"
+    }
+
+    @Test
+    fun `getLocale falls back to the system language when no application locale is set`() {
+        LocaleUtils.setLocale(context, "")
+
+        LocaleUtils.getLocale(context) shouldBe Locale.getDefault().language
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/ActivityBlockerViewModelTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/ActivityBlockerViewModelTest.kt
@@ -1,0 +1,92 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import io.github.warleysr.dechainer.DechainerAccessibilityService
+import io.github.warleysr.dechainer.DechainerAccessibilityService.Companion.ActivityLog
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.installApp
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+/**
+ * Exercises [ActivityBlockerViewModel]'s own logic through [Fixtures]: a class name is added only once
+ * and never when blank, a removal is persisted so a freshly built view model no longer loads it, and
+ * getGroupedAccessedActivities groups the static access log by package, orders the groups by app label
+ * rather than package name, and falls back to the raw package name when the package is not installed.
+ */
+@RunWith(AndroidJUnit4::class)
+class ActivityBlockerViewModelTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val blockedClass = "com.example.socialapp.FeedActivity"
+    private val otherClass = "com.example.socialapp.ProfileActivity"
+
+    @Test
+    fun `addBlockedActivity ignores a duplicate class name`() {
+        val viewModel = Fixtures.activityBlockerViewModel()
+
+        viewModel.addBlockedActivity(blockedClass)
+        viewModel.addBlockedActivity(blockedClass)
+
+        viewModel.blockedActivities shouldContainExactly listOf(blockedClass)
+        prefs("activity_blocker_prefs").getStringSet("blocked_activities", emptySet()) shouldBe
+            setOf(blockedClass)
+    }
+
+    @Test
+    fun `addBlockedActivity ignores a blank class name`() {
+        val viewModel = Fixtures.activityBlockerViewModel()
+
+        viewModel.addBlockedActivity("")
+        viewModel.addBlockedActivity("   ")
+
+        viewModel.blockedActivities.shouldBeEmpty()
+        prefs("activity_blocker_prefs").getStringSet("blocked_activities", emptySet()) shouldBe
+            emptySet<String>()
+    }
+
+    @Test
+    fun `removing a blocked activity persists across a reload`() {
+        val viewModel = Fixtures.activityBlockerViewModel()
+        viewModel.addBlockedActivity(blockedClass)
+        viewModel.addBlockedActivity(otherClass)
+
+        viewModel.removeBlockedActivity(blockedClass)
+
+        prefs("activity_blocker_prefs").getStringSet("blocked_activities", emptySet()) shouldBe
+            setOf(otherClass)
+        Fixtures.activityBlockerViewModel().blockedActivities shouldContainExactly listOf(otherClass)
+    }
+
+    @Test
+    fun `getGroupedAccessedActivities groups by package and sorts by app label`() {
+        installApp("com.example.zeta", "Alpha App")
+        installApp("com.example.alpha", "Zeta App")
+        DechainerAccessibilityService.accessedActivities.add(ActivityLog("com.example.zeta", "zeta.Home"))
+        DechainerAccessibilityService.accessedActivities.add(ActivityLog("com.example.zeta", "zeta.Detail"))
+        DechainerAccessibilityService.accessedActivities.add(ActivityLog("com.example.alpha", "alpha.Main"))
+
+        val grouped = Fixtures.activityBlockerViewModel().getGroupedAccessedActivities()
+
+        grouped.map { it.appName } shouldContainExactly listOf("Alpha App", "Zeta App")
+        grouped.first { it.packageName == "com.example.zeta" }.activities.size shouldBe 2
+    }
+
+    @Test
+    fun `getGroupedAccessedActivities falls back to the package name for an uninstalled package`() {
+        val ghost = "com.example.ghost"
+        DechainerAccessibilityService.accessedActivities.add(ActivityLog(ghost, "ghost.Main"))
+
+        val grouped = Fixtures.activityBlockerViewModel().getGroupedAccessedActivities()
+
+        grouped.first { it.packageName == ghost }.appName shouldBe ghost
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/AppsViewModelTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/AppsViewModelTest.kt
@@ -1,0 +1,89 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.DechainerDeviceAdminReceiver
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.awaitUntil
+import io.github.warleysr.dechainer.support.installApp
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises [AppsViewModel]'s persistence and resilience logic through [Fixtures]: a time limit of zero
+ * deletes its key rather than storing a literal zero the service would read as a real limit, usage read
+ * back from the stats file comes out raw in millis and floored when asked for whole minutes, a reopen
+ * time round-trips through the view model's own setter and getter and clears on zero, and loadApps keeps
+ * every app in the list when the unprivileged device policy manager raises a SecurityException for each
+ * one instead of collapsing to an empty list.
+ */
+@RunWith(AndroidJUnit4::class)
+class AppsViewModelTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val targetPackage = "com.example.socialapp"
+
+    @Test
+    fun `setting a time limit of zero removes the key instead of storing zero`() {
+        val viewModel = Fixtures.appsViewModel()
+        viewModel.setAppTimeLimit(targetPackage, 30)
+        prefs("app_limits").getInt(targetPackage, -1) shouldBe 30
+
+        viewModel.setAppTimeLimit(targetPackage, 0)
+
+        prefs("app_limits").contains(targetPackage) shouldBe false
+    }
+
+    @Test
+    fun `getAppUsage returns raw millis and floors the whole-minute conversion`() {
+        prefs("internal_usage_stats").edit().putLong(targetPackage, 90_000L).commit()
+
+        val viewModel = Fixtures.appsViewModel()
+
+        viewModel.getAppUsage(targetPackage) shouldBe 90_000L
+        viewModel.getAppUsage(targetPackage, inMinutes = true) shouldBe 1L
+        viewModel.getAppUsage("com.example.unknown") shouldBe 0L
+    }
+
+    @Test
+    fun `a reopen time round-trips through the view model and clears on zero`() {
+        val viewModel = Fixtures.appsViewModel()
+
+        viewModel.setAppReopenTime(targetPackage, 60)
+        viewModel.getAppReopenTime(targetPackage) shouldBe 60
+
+        viewModel.setAppReopenTime(targetPackage, 0)
+        viewModel.getAppReopenTime(targetPackage) shouldBe 0
+        prefs("reopen_times").contains(targetPackage) shouldBe false
+    }
+
+    @Test
+    fun `loadApps keeps apps listed when the device policy manager denies access`() {
+        val userApp = "com.example.userapp"
+        installApp(userApp, "User App")
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+        shouldThrow<SecurityException> { dpm.isApplicationHidden(admin, userApp) }
+
+        val viewModel = Fixtures.appsViewModel()
+        awaitUntil { viewModel.apps.any { it.packageName == userApp } }
+
+        val app = viewModel.apps.first { it.packageName == userApp }
+        app.isHidden shouldBe false
+        app.isUninstallBlocked shouldBe false
+        viewModel.apps.map { it.packageName } shouldContain userApp
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/BlockedWordsViewModelTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/BlockedWordsViewModelTest.kt
@@ -1,0 +1,107 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.awaitUntil
+import io.github.warleysr.dechainer.support.installApp
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises [BlockedWordsViewModel]'s own logic through [Fixtures]: word text is normalized (trimmed,
+ * blank lines dropped, duplicates collapsed) before it is persisted, toggling a target package is a
+ * reversible set operation that never clobbers other selections, the passive-words map is rebuilt from
+ * the per-package prefixed keys on construction and drops a package once its words are cleared, and the
+ * installable-apps list leaves out both the app's own package and system apps.
+ */
+@RunWith(AndroidJUnit4::class)
+class BlockedWordsViewModelTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val targetPackage = "com.example.socialapp"
+    private val otherPackage = "com.example.other"
+
+    @Test
+    fun `updateWords trims, drops blank lines and de-duplicates before persisting`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.updateWords("  kumar  \n\n  bahis  \nkumar\n   ")
+
+        prefs("blocked_words_prefs").getStringSet("blocked_words", emptySet()) shouldBe
+            setOf("kumar", "bahis")
+    }
+
+    @Test
+    fun `toggling a package on then off returns the selection to empty`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.toggleAppSelection(targetPackage)
+        viewModel.targetPackages shouldBe setOf(targetPackage)
+
+        viewModel.toggleAppSelection(targetPackage)
+        viewModel.targetPackages shouldBe emptySet<String>()
+        prefs("blocked_words_prefs").getStringSet("target_packages", emptySet()) shouldBe
+            emptySet<String>()
+    }
+
+    @Test
+    fun `toggling a second package keeps the first one selected`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.toggleAppSelection(targetPackage)
+        viewModel.toggleAppSelection(otherPackage)
+
+        viewModel.targetPackages shouldBe setOf(targetPackage, otherPackage)
+        prefs("blocked_words_prefs").getStringSet("target_packages", emptySet()) shouldBe
+            setOf(targetPackage, otherPackage)
+    }
+
+    @Test
+    fun `passive words are loaded into the map when the view model is constructed`() {
+        prefs("blocked_words_prefs").edit()
+            .putStringSet("passive_words_$targetPackage", setOf("kumar"))
+            .commit()
+
+        val viewModel = Fixtures.blockedWordsViewModel()
+
+        viewModel.passiveWordsMap shouldBe mapOf(targetPackage to "kumar")
+    }
+
+    @Test
+    fun `clearing passive words removes the package from the map`() {
+        val viewModel = Fixtures.blockedWordsViewModel()
+        viewModel.updatePassiveWords(targetPackage, "kumar")
+        viewModel.passiveWordsMap shouldBe mapOf(targetPackage to "kumar")
+
+        viewModel.updatePassiveWords(targetPackage, "")
+
+        viewModel.passiveWordsMap shouldBe emptyMap<String, String>()
+    }
+
+    @Test
+    fun `the apps list excludes the app's own package and system apps`() {
+        val userApp = "com.example.userapp"
+        val systemApp = "com.android.systemapp"
+        installApp(userApp, "User App")
+        installApp(systemApp, "System App", system = true)
+
+        val viewModel = Fixtures.blockedWordsViewModel()
+        awaitUntil { viewModel.apps.any { it.packageName == userApp } }
+
+        val ownPackage = ApplicationProvider.getApplicationContext<Context>().packageName
+        val packages = viewModel.apps.map { it.packageName }
+        packages shouldContain userApp
+        packages shouldNotContain systemApp
+        packages shouldNotContain ownPackage
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/BrowserRestrictionsViewModelTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/BrowserRestrictionsViewModelTest.kt
@@ -1,0 +1,77 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.prefs
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+/**
+ * Exercises [BrowserRestrictionsViewModel]'s blocked-list persistence through [Fixtures]: saved lists
+ * survive a round trip through the `blocked_lists_json` prefs into a freshly built view model with their
+ * sites trimmed and blank lines dropped, a malformed json leaves the list empty instead of crashing on
+ * construction, saving with an existing id updates that list in place, and saving with a null id appends
+ * a new list rather than replacing one.
+ */
+@RunWith(AndroidJUnit4::class)
+class BrowserRestrictionsViewModelTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    @Test
+    fun `saved lists round-trip through the JSON into a fresh view model`() {
+        val viewModel = Fixtures.browserRestrictionsViewModel()
+        viewModel.saveOrUpdateList("list-1", "Adult", "a.com\n  b.com  \n\n")
+        viewModel.saveOrUpdateList("list-2", "Gambling", "c.com")
+
+        prefs("browser_prefs").getString("blocked_lists_json", null) shouldNotBe null
+
+        Fixtures.browserRestrictionsViewModel().blockedLists shouldContainExactly listOf(
+            BlockedList("list-1", "Adult", listOf("a.com", "b.com")),
+            BlockedList("list-2", "Gambling", listOf("c.com"))
+        )
+    }
+
+    @Test
+    fun `a malformed blocked_lists_json leaves the list empty without crashing`() {
+        prefs("browser_prefs").edit().putString("blocked_lists_json", "{ not valid json ]").commit()
+
+        lateinit var viewModel: BrowserRestrictionsViewModel
+        shouldNotThrowAny { viewModel = Fixtures.browserRestrictionsViewModel() }
+
+        viewModel.blockedLists.shouldBeEmpty()
+    }
+
+    @Test
+    fun `saveOrUpdateList with an existing id updates the list in place`() {
+        val viewModel = Fixtures.browserRestrictionsViewModel()
+        viewModel.saveOrUpdateList("list-1", "Adult", "a.com")
+
+        viewModel.saveOrUpdateList("list-1", "Adult v2", "a.com\nb.com")
+
+        viewModel.blockedLists shouldContainExactly listOf(
+            BlockedList("list-1", "Adult v2", listOf("a.com", "b.com"))
+        )
+    }
+
+    @Test
+    fun `saveOrUpdateList with a null id appends a new list`() {
+        val viewModel = Fixtures.browserRestrictionsViewModel()
+        viewModel.saveOrUpdateList("list-1", "Adult", "a.com")
+
+        viewModel.saveOrUpdateList(null, "Gambling", "c.com")
+
+        viewModel.blockedLists.size shouldBe 2
+        viewModel.blockedLists.map { it.id } shouldContainExactly
+            viewModel.blockedLists.map { it.id }.distinct()
+        viewModel.blockedLists[1].id shouldNotBe "list-1"
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/DegradedModeTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/DegradedModeTest.kt
@@ -1,0 +1,75 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * With no device owner granted and Shizuku absent — the state a fresh install is in — each test
+ * constructs one of the six ViewModels through [Fixtures] and exercises its primary mutator, asserting
+ * that it degrades to doing nothing rather than throwing. This is the layer that proves the product
+ * stays crash-free when its privileges are missing. Nothing here grants a device owner or touches Shizuku, 
+ * so the environment is genuinely unprivileged.
+ */
+@RunWith(AndroidJUnit4::class)
+class DegradedModeTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val targetPackage = "com.example.socialapp"
+
+    @Test
+    fun `BlockedWordsViewModel constructs and toggles selection without device owner`() {
+        shouldNotThrowAny {
+            val viewModel = Fixtures.blockedWordsViewModel()
+            viewModel.toggleAppSelection(targetPackage)
+        }
+    }
+
+    @Test
+    fun `AppsViewModel constructs and applies a limit and blocking without device owner`() {
+        shouldNotThrowAny {
+            val viewModel = Fixtures.appsViewModel()
+            viewModel.setAppTimeLimit(targetPackage, 30)
+            viewModel.blockApp(targetPackage, true)
+        }
+    }
+
+    @Test
+    fun `ActivityBlockerViewModel constructs and adds a blocked activity without device owner`() {
+        shouldNotThrowAny {
+            val viewModel = Fixtures.activityBlockerViewModel()
+            viewModel.addBlockedActivity("com.example.app.SettingsActivity")
+        }
+    }
+
+    @Test
+    fun `BrowserRestrictionsViewModel constructs and saves a list without device owner`() {
+        shouldNotThrowAny {
+            val viewModel = Fixtures.browserRestrictionsViewModel()
+            viewModel.saveOrUpdateList("list-1", "Adult", "a.com")
+        }
+    }
+
+    @Test
+    fun `RestrictionsViewModel constructs and applies changes without device owner`() {
+        shouldNotThrowAny {
+            val viewModel = Fixtures.restrictionsViewModel()
+            viewModel.applyChanges()
+        }
+    }
+
+    @Test
+    fun `DeviceOwnerViewModel constructs and reports no privileges without device owner`() {
+        val viewModel = Fixtures.deviceOwnerViewModel()
+
+        viewModel.isDeviceOwner() shouldBe false
+        viewModel.isShizukuInstalled() shouldBe false
+    }
+}

--- a/app/src/test/java/io/github/warleysr/dechainer/viewmodels/RestrictionsViewModelTest.kt
+++ b/app/src/test/java/io/github/warleysr/dechainer/viewmodels/RestrictionsViewModelTest.kt
@@ -1,0 +1,84 @@
+package io.github.warleysr.dechainer.viewmodels
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.UserManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.warleysr.dechainer.DechainerDeviceAdminReceiver
+import io.github.warleysr.dechainer.support.DechainerTestRule
+import io.github.warleysr.dechainer.support.Fixtures
+import io.github.warleysr.dechainer.support.ShadowDechainerDpm
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Exercises [RestrictionsViewModel] through [Fixtures]: the three recommended keys resolve to distinct
+ * non-blank UserManager constants, the draft toggles are pure in-memory state, and applyChanges
+ * reconciles the applied map with the draft by routing add/clear through the device policy manager —
+ * backed by [ShadowDechainerDpm] — and reading it back. Run under API 30 and 36 so the apply/load cycle
+ * over the framework Bundle is proven on both. The reflection-derived `otherKeys` list is deliberately
+ * not asserted: Robolectric's instrumented android jar strips `final` off UserManager's DISALLOW_*
+ * constants, so the view model's `Modifier.isFinal` filter drops every key and otherKeys is always empty
+ * here — a real device keeps them final. Only the recommended keys, read directly, survive this
+ * environment.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [30, 36], shadows = [ShadowDechainerDpm::class])
+class RestrictionsViewModelTest {
+
+    @get:Rule
+    val rule = DechainerTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+    private val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+
+    @Test
+    fun `recommendedKeys resolve to three distinct non-blank restriction keys`() {
+        val viewModel = Fixtures.restrictionsViewModel()
+
+        viewModel.recommendedKeys.size shouldBe 3
+        viewModel.recommendedKeys.toSet().size shouldBe 3
+        viewModel.recommendedKeys.forEach { it.shouldNotBeBlank() }
+    }
+
+    @Test
+    fun `toggleDraft, toggleAllDrafts and isAllDraftsEnabled are pure draft-state operations`() {
+        val viewModel = Fixtures.restrictionsViewModel()
+        val keys = listOf(UserManager.DISALLOW_CONFIG_VPN, UserManager.DISALLOW_FACTORY_RESET)
+
+        viewModel.toggleDraft(keys[0], true)
+        viewModel.draftRestrictions[keys[0]] shouldBe true
+
+        viewModel.toggleAllDrafts(keys, true)
+        viewModel.isAllDraftsEnabled(keys) shouldBe true
+
+        viewModel.toggleDraft(keys[1], false)
+        viewModel.isAllDraftsEnabled(keys) shouldBe false
+    }
+
+    @Test
+    fun `applyChanges reconciles applied state with the draft through the policy manager`() {
+        shadowOf(dpm).setDeviceOwner(admin)
+        val viewModel = Fixtures.restrictionsViewModel()
+        val key = UserManager.DISALLOW_CONFIG_VPN
+
+        viewModel.toggleDraft(key, true)
+        viewModel.applyChanges()
+
+        viewModel.appliedRestrictions[key] shouldBe true
+        viewModel.draftRestrictions[key] shouldBe true
+
+        viewModel.toggleDraft(key, false)
+        viewModel.applyChanges()
+
+        viewModel.appliedRestrictions[key] shouldBe false
+    }
+}


### PR DESCRIPTION
Adds a behavior-focused test suite (103 tests, 108 runs) that locks the app's externally observable behavior in place — guarding against silent regressions where blocking stops with no crash or log.

- Pipeline (vertical-slice) tests: write through the real ViewModels and verify enforcement by driving the real AccessibilityService — blocked words, activities, time limits, reopen cooldown, browser blocklists. These pin the core promise: blocking always fires.
- Persistence-contract tests: lock the SharedPreferences keys/types that silently link the UI and enforcement layers across 8 files.
- Recovery-gate tests: the session lock never self-opens (wrong code, 10-min timeout).
- Degraded-mode tests: no ViewModel/service crash without device-owner or Shizuku.
- Manifest & string-resource integrity checks.

Also surfaces 3 latent bugs — misconfigured settingsActivity (committed as an intentional failing test), passive-word event delivery, and browser list-id collision.