### PR TITLE
PR Title: feat: Add "Sober Up" Network Blocker & Refactor Keyword/Site Restrictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 .kotlin
+.idea/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 
 android {
     namespace = "io.github.warleysr.dechainer"
-    compileSdk {
-        version = release(36)
-    }
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "io.github.warleysr.dechainer"

--- a/app/src/main/java/io/github/warleysr/dechainer/BrowserRestrictionsManager.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/BrowserRestrictionsManager.kt
@@ -10,6 +10,8 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.core.net.toUri
 import io.github.warleysr.dechainer.viewmodels.DeviceOwnerViewModel
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
 
 class BrowserRestrictionsManager(private val context: Context) {
 
@@ -21,23 +23,19 @@ class BrowserRestrictionsManager(private val context: Context) {
         val browserCategoryIntent = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_APP_BROWSER)
         }
-
         val httpIntent = Intent(Intent.ACTION_VIEW, "http://www.example.com".toUri())
         val httpsIntent = Intent(Intent.ACTION_VIEW, "https://www.example.com".toUri())
 
-        val flags =
-            PackageManager.MATCH_ALL
+        val flags = PackageManager.MATCH_ALL
 
         listOf(browserCategoryIntent, httpIntent, httpsIntent).forEach { intent ->
             pm.queryIntentActivities(intent, flags).forEach { resolveInfo ->
                 val packageName = resolveInfo.activityInfo.packageName
-
                 if (packageName != context.packageName && resolvedPackages.add(packageName)) {
                     results.add(resolveInfo)
                 }
             }
         }
-
         return results
     }
 
@@ -47,7 +45,6 @@ class BrowserRestrictionsManager(private val context: Context) {
 
     fun getPossibleTorrentApps(): Set<String> {
         val pm = context.packageManager
-
         val magnetIntent = Intent(Intent.ACTION_VIEW, "magnet:?xt=urn:btih:1234567890ABCDEF".toUri())
         val magnetHandlers = pm.queryIntentActivities(magnetIntent, PackageManager.MATCH_DEFAULT_ONLY)
 
@@ -57,7 +54,6 @@ class BrowserRestrictionsManager(private val context: Context) {
         val torrentHandlers = pm.queryIntentActivities(torrentIntent, PackageManager.MATCH_DEFAULT_ONLY)
 
         val suspiciousPackages = (magnetHandlers + torrentHandlers).map { it.activityInfo.packageName }.toSet()
-
         return suspiciousPackages
     }
 
@@ -76,10 +72,16 @@ class BrowserRestrictionsManager(private val context: Context) {
     }
 
     fun applyRestrictions(installed: Boolean = false) {
+        val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val adminName = ComponentName(context, io.github.warleysr.dechainer.DechainerDeviceAdminReceiver::class.java)
+
+        // Prevent SecurityException if the app is not the Device Owner
+        if (!dpm.isAdminActive(adminName) || !dpm.isDeviceOwnerApp(adminName.packageName)) return
+
         val prefs = context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
         val json = prefs.getString("blocked_lists_json", null) ?: return
-
         val allSites = mutableSetOf<String>()
+
         try {
             val array = JSONArray(json)
             for (i in 0 until array.length()) {
@@ -92,14 +94,15 @@ class BrowserRestrictionsManager(private val context: Context) {
 
         val urlRestrictions = Bundle().apply {
             putStringArray("URLBlocklist", allSites.toTypedArray())
-
             if (installed)
                 putBoolean("ForceGoogleSafeSearch", true)
         }
 
         val viewModel = DeviceOwnerViewModel()
         getPossibleBrowsers().forEach { info ->
-            viewModel.setApplicationRestrictions(info.activityInfo.packageName, urlRestrictions)
+            try {
+                viewModel.setApplicationRestrictions(info.activityInfo.packageName, urlRestrictions)
+            } catch (e: Exception) { e.printStackTrace() }
         }
     }
 }

--- a/app/src/main/java/io/github/warleysr/dechainer/DechainerAccessibilityService.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/DechainerAccessibilityService.kt
@@ -36,15 +36,26 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.max
+import io.github.warleysr.dechainer.utils.NetworkBlockManager
 
 @SuppressLint("AccessibilityPolicy")
 class DechainerAccessibilityService : AccessibilityService() {
+
+    @Volatile private var isNetworkBlocking = false
+    private var soberUpPrefs: SharedPreferences? = null
+    private var isSoberUpEnabled = false
+    private var sensitiveKeywordsList: List<String> = emptyList()
+    private var browserPackages: Set<String> = emptySet()
+
+    private var wasTyping: Boolean = false
+    private var lastTypedText: String = ""
+    // ---------------------
 
     private val handler = Handler(Looper.getMainLooper())
     private var currentPackage: String? = null
     private var sessionStartTime: Long = 0
     private var lastCheckDate: String = LocalDate.now().toString()
-    private val lastClosedTimes = HashMap<String, Long>();
+    private val lastClosedTimes = HashMap<String, Long>()
 
     private lateinit var limitPrefs: SharedPreferences
     private lateinit var usagePrefs: SharedPreferences
@@ -58,6 +69,15 @@ class DechainerAccessibilityService : AccessibilityService() {
     private var targetPackages: Set<String> = emptySet()
 
     private val serviceScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    private fun updateSensitiveWords() {
+        isSoberUpEnabled = soberUpPrefs?.getBoolean("enabled", false) ?: false
+        val userKeywords = soberUpPrefs?.getStringSet("sensitive_words", emptySet()) ?: emptySet()
+        val baseKeywords = try {
+            resources.openRawResource(R.raw.block_keywords_expanded).bufferedReader().readLines().filter { it.isNotBlank() }
+        } catch (e: Exception) { emptyList() }
+        sensitiveKeywordsList = baseKeywords + userKeywords.toList()
+    }
 
     private val packageReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -87,7 +107,6 @@ class DechainerAccessibilityService : AccessibilityService() {
                 serviceScope.launch(Dispatchers.IO) {
                     try {
                         val info = PlayStoreRatingFetcher.fetch(packageName)
-
 
                         if (info.hasExplicitContent && info.contentRating == "Rated 18+")
                             withContext(Dispatchers.Main) {
@@ -134,18 +153,49 @@ class DechainerAccessibilityService : AccessibilityService() {
                     currentPackage?.let { startTracking(it) }
                 }
             }
-
             blockedWordsPrefs -> {
                 updateForbiddenPatterns()
+            }
+            soberUpPrefs -> {
+                updateSensitiveWords()
             }
         }
     }
 
+    data class ScreenExtraction(val text: String, val isTyping: Boolean)
+
+    private fun extractSearchBoxTextAndFocus(): ScreenExtraction {
+        val rootNode = rootInActiveWindow ?: return ScreenExtraction("", false)
+        val sb = StringBuilder()
+        var isTyping = false
+
+        fun traverse(node: AccessibilityNodeInfo?) {
+            if (node == null) return
+
+            // ONLY extract text if the node is an editable field (like a URL bar or Search box)
+            if (node.isEditable || node.className?.contains("EditText") == true) {
+                if (node.isFocused) {
+                    isTyping = true
+                }
+                node.text?.let { sb.append(it).append(" ") }
+            }
+
+            for (i in 0 until node.childCount) {
+                traverse(node.getChild(i))
+            }
+        }
+
+        traverse(rootNode)
+        rootNode.recycle()
+        return ScreenExtraction(sb.toString().lowercase(), isTyping)
+    }
+
     private fun updateForbiddenPatterns() {
+        browserPackages = BrowserRestrictionsManager(applicationContext).getPossibleBrowsers().map { it.activityInfo.packageName }.toSet()
         val words = blockedWordsPrefs.getStringSet("blocked_words", emptySet()) ?: emptySet()
         forbiddenPatterns = words.associateWith { word ->
             Regex(
-                "(?<![\\p{L}\\p{N}_])${Regex.escape(word)}(?![\\p{L}\\p{N}_])",
+                "(?<![\\\\p{L}\\\\p{N}_])${Regex.escape(word)}(?![\\\\p{L}\\\\p{N}_])",
                 RegexOption.IGNORE_CASE
             )
         }
@@ -160,7 +210,7 @@ class DechainerAccessibilityService : AccessibilityService() {
                 if (wordsSet.isNotEmpty()) {
                     passiveMap[pkg] = wordsSet.associateWith { word ->
                         Regex(
-                            "(?<![\\p{L}\\p{N}_])${Regex.escape(word)}(?![\\p{L}\\p{N}_])",
+                            "(?<![\\\\p{L}\\\\p{N}_])${Regex.escape(word)}(?![\\\\p{L}\\\\p{N}_])",
                             RegexOption.IGNORE_CASE
                         )
                     }
@@ -214,11 +264,14 @@ class DechainerAccessibilityService : AccessibilityService() {
         blockedWordsPrefs = getSharedPreferences("blocked_words_prefs", MODE_PRIVATE)
         securityPrefs = getSharedPreferences("security_prefs", MODE_PRIVATE)
         ratingPrefs = getSharedPreferences("app_ratings", MODE_PRIVATE)
+        soberUpPrefs = getSharedPreferences("sober_up_prefs", MODE_PRIVATE)
 
         limitPrefs.registerOnSharedPreferenceChangeListener(prefsListener)
         blockedWordsPrefs.registerOnSharedPreferenceChangeListener(prefsListener)
+        soberUpPrefs?.registerOnSharedPreferenceChangeListener(prefsListener)
 
         updateForbiddenPatterns()
+        updateSensitiveWords()
 
         val blockedPackages = getControlledPackages()
         suspendPackages(blockedPackages, false)
@@ -264,6 +317,7 @@ class DechainerAccessibilityService : AccessibilityService() {
         unregisterReceiver(screenReceiver)
         limitPrefs.unregisterOnSharedPreferenceChangeListener(prefsListener)
         blockedWordsPrefs.unregisterOnSharedPreferenceChangeListener(prefsListener)
+        soberUpPrefs?.unregisterOnSharedPreferenceChangeListener(prefsListener)
         stopTrackingAndSave()
         isRunning = false
 
@@ -277,10 +331,10 @@ class DechainerAccessibilityService : AccessibilityService() {
                 dpm.addUserRestriction(admin, UserManager.DISALLOW_INSTALL_APPS)
             }
 
-            val intent = Intent(
+            val intentActivity = Intent(
                 this@DechainerAccessibilityService, AccessibilityRequestActivity::class.java
             ).apply { flags = FLAG_ACTIVITY_NEW_TASK }
-            startActivity(intent)
+            startActivity(intentActivity)
         }
 
         return super.onUnbind(intent)
@@ -293,7 +347,6 @@ class DechainerAccessibilityService : AccessibilityService() {
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
         if (event.packageName == packageName) return
 
-        // App tracking to control time limits and time between re-openings
         if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
             val newPackage = event.packageName?.toString() ?: return
             val className = event.className?.toString() ?: return
@@ -305,6 +358,8 @@ class DechainerAccessibilityService : AccessibilityService() {
             if (newPackage != currentPackage) {
                 stopTrackingAndSave()
                 currentPackage = newPackage
+                wasTyping = false // Reset typing state on app switch
+                lastTypedText = ""
                 sessionStartTime = SystemClock.elapsedRealtime()
                 checkDateReset()
                 startTracking(newPackage)
@@ -321,8 +376,6 @@ class DechainerAccessibilityService : AccessibilityService() {
                     performGlobalAction(GLOBAL_ACTION_BACK)
             }
         }
-
-        // Active blocking: when the user types the forbidden word
         else if (event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED) {
             if (event.source?.isEditable == false) return
 
@@ -341,10 +394,52 @@ class DechainerAccessibilityService : AccessibilityService() {
 
             showBlockedActivity(forbiddenWord)
         }
+        else if (event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED || event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED) {
+            val pkg = currentPackage ?: event.packageName?.toString() ?: return
 
-        // Passive blocking: when the forbidden word appears on the screen
-        else if (event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) {
-            val pkg = currentPackage ?: return
+            // --- SOBER UP BLOCK LOGIC ---
+            if (pkg == "com.android.chrome" || browserPackages.contains(pkg)) {
+                if (isSoberUpEnabled) {
+                    val extraction = extractSearchBoxTextAndFocus()
+
+                    if (extraction.isTyping) {
+                        // User is currently typing in the URL bar/Search box
+                        wasTyping = true
+                        lastTypedText = extraction.text
+                    } else if (wasTyping) {
+                        // User was typing, but focus was just lost (they hit Enter/Search or closed keyboard)
+                        wasTyping = false
+
+                        // Fallback to the last typed text if the browser cleared the URL bar on submission
+                        val textToCheck = if (extraction.text.isNotBlank()) extraction.text else lastTypedText
+                        val matchedWord = sensitiveKeywordsList.firstOrNull { textToCheck.contains(it) }
+
+                        if (matchedWord != null && !isNetworkBlocking) {
+                            isNetworkBlocking = true
+
+                            performGlobalAction(GLOBAL_ACTION_BACK)
+                            performGlobalAction(GLOBAL_ACTION_BACK)
+
+                            NetworkBlockManager.triggerBlock(applicationContext)
+
+                            val intentActivity = Intent(this, BlockedWordActivity::class.java).apply {
+                                flags = FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                putExtra("word", matchedWord)
+                                putExtra("isNetworkBlock", true)
+                            }
+                            startActivity(intentActivity)
+
+                            handler.postDelayed({
+                                isNetworkBlocking = false
+                            }, 2000)
+                            return
+                        }
+                    }
+                }
+            }
+            // ---------------------------------
+
+            if (!targetPackages.contains(pkg)) return
 
             if (!ratingPrefs.contains(pkg) && !checkingRating) {
                 checkingRating = true
@@ -367,7 +462,6 @@ class DechainerAccessibilityService : AccessibilityService() {
             }
 
             val passivePatterns = passiveForbiddenPatterns[pkg] ?: return
-
             val screenText = buildScreenText(event) ?: return
 
             passivePatterns.forEach { (word, regex) ->
@@ -382,9 +476,7 @@ class DechainerAccessibilityService : AccessibilityService() {
 
     private fun buildScreenText(event: AccessibilityEvent): String? {
         val sb = StringBuilder()
-
         event.text.forEach { sb.append(it).append(' ') }
-
         event.source?.also { root ->
             fun traverse(node: AccessibilityNodeInfo?) {
                 node ?: return
@@ -395,27 +487,25 @@ class DechainerAccessibilityService : AccessibilityService() {
             traverse(root)
             root.recycle()
         }
-
         return sb.toString().trim().takeIf { it.isNotBlank() }
     }
 
     private fun showBlockedActivity(forbiddenWord: String) {
         serviceScope.launch {
             withContext(Dispatchers.Main) {
-                val intent = Intent(
+                val intentActivity = Intent(
                     this@DechainerAccessibilityService, BlockedWordActivity::class.java
                 ).apply {
                     flags = FLAG_ACTIVITY_NEW_TASK
                     putExtra("word", forbiddenWord)
                 }
-                startActivity(intent)
+                startActivity(intentActivity)
             }
         }
     }
 
     private fun suspendPackages(packages: Array<String>, suspend: Boolean = true) {
-        val dpm =
-            applicationContext.getSystemService(DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val dpm = applicationContext.getSystemService(DEVICE_POLICY_SERVICE) as DevicePolicyManager
         val admin = ComponentName(applicationContext, DechainerDeviceAdminReceiver::class.java)
         if (!dpm.isAdminActive(admin)) return
         dpm.setPackagesSuspended(admin, packages, suspend)
@@ -499,8 +589,7 @@ class DechainerAccessibilityService : AccessibilityService() {
             putExtra("limit", limit)
         })
     }
-    
-    
+
     private fun checkDateReset() {
         val today = LocalDate.now().toString()
         if (today != lastCheckDate) {
@@ -520,5 +609,4 @@ class DechainerAccessibilityService : AccessibilityService() {
         }
         return 0
     }
-
 }

--- a/app/src/main/java/io/github/warleysr/dechainer/DechainerApplication.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/DechainerApplication.kt
@@ -2,6 +2,7 @@ package io.github.warleysr.dechainer
 
 import android.app.Application
 import io.github.warleysr.dechainer.security.SecurityManager
+import io.github.warleysr.dechainer.utils.NetworkBlockManager
 import timber.log.Timber
 
 class DechainerApplication : Application() {
@@ -18,6 +19,8 @@ class DechainerApplication : Application() {
         super.onCreate()
 
         instance = this
+
+        NetworkBlockManager.checkAndRestoreOnBoot(this) // Added boot check
 
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/io/github/warleysr/dechainer/activities/BlockedWordActivity.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/activities/BlockedWordActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.NoAdultContent
 import androidx.compose.material.icons.outlined.RemoveRedEye
+import androidx.compose.material.icons.outlined.WifiOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,14 +43,79 @@ class BlockedWordActivity : ComponentActivity() {
 
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
+        val forbiddenWord = intent.getStringExtra("word") ?: "Unknown"
+        val isNetworkBlock = intent.getBooleanExtra("isNetworkBlock", false)
+
         setContent {
-            BlockedWordActivity(
-                forbiddenWord = intent.getStringExtra("word")!!,
+            BlockedWordActivityScreen(
+                forbiddenWord = forbiddenWord,
+                isNetworkBlock = isNetworkBlock,
                 onClose = { finishAfterTransition() }
             )
         }
+
+
     }
 }
+
+
+@Composable
+fun BlockedWordActivityScreen(forbiddenWord: String, isNetworkBlock: Boolean, onClose: () -> Unit) {
+    var showWordBlurred by remember { mutableStateOf(true) }
+
+    // Change colors based on the severity of the block
+    val bgColor = if (isNetworkBlock) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.background
+    val icon = if (isNetworkBlock) Icons.Outlined.WifiOff else Icons.Default.NoAdultContent
+
+    Surface(modifier = Modifier.fillMaxSize(), color = bgColor) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(64.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = if (isNetworkBlock) "Internet Disabled!" else stringResource(R.string.blocked_word),
+                style = MaterialTheme.typography.headlineMedium
+            )
+
+            val reasonText = if (isNetworkBlock) {
+                "A highly sensitive keyword was detected. To help you sober up, your internet access has been temporarily disabled."
+            } else {
+                stringResource(R.string.blocked_word_description)
+            }
+
+            Text(
+                text = reasonText,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text("Keyword triggered:", style = MaterialTheme.typography.labelMedium)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = forbiddenWord,
+                    modifier = Modifier.blur(if (showWordBlurred) 8.dp else 0.dp),
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                IconButton(onClick = { showWordBlurred = !showWordBlurred }) {
+                    Icon(Icons.Outlined.RemoveRedEye, null)                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+            Button(onClick = onClose) {
+                Text(stringResource(R.string.close))
+            }
+        }
+    }
+}
+
 
 @Composable
 fun BlockedWordActivity(forbiddenWord: String, onClose: () -> Unit) {

--- a/app/src/main/java/io/github/warleysr/dechainer/activities/MainActivity.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/activities/MainActivity.kt
@@ -32,6 +32,10 @@ import io.github.warleysr.dechainer.ui.theme.DechainerTheme
 import io.github.warleysr.dechainer.viewmodels.DeviceOwnerViewModel
 import kotlinx.coroutines.delay
 
+import androidx.compose.material.icons.outlined.WifiOff
+import androidx.compose.ui.platform.LocalContext
+
+
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,6 +43,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             DechainerTheme {
+
+
                 val viewModel: DeviceOwnerViewModel = viewModel()
                 viewModel.addShizukuListener()
 
@@ -69,12 +75,23 @@ class MainActivity : ComponentActivity() {
                                     }
                                 }
                             },
+
                             actions = {
+
+                                SoberUpTimerAction()
+
+                                var currentTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
+                                LaunchedEffect(Unit) {
+                                    while(true) {
+                                        currentTime = System.currentTimeMillis()
+                                        kotlinx.coroutines.delay(1000)
+                                    }
+                                }
+
                                 if (SecurityManager.isSessionActive()) {
                                     val remaining = SecurityManager.sessionEndTime - currentTime
                                     val minutes = (remaining / 1000) / 60
                                     val seconds = (remaining / 1000) % 60
-                                    
                                     Row(verticalAlignment = Alignment.CenterVertically) {
                                         Icon(Icons.Outlined.LockClock, null, modifier = Modifier.padding(end = 4.dp))
                                         Text(
@@ -87,6 +104,7 @@ class MainActivity : ComponentActivity() {
                                     }
                                 }
                             }
+
                         )
                     },
                     bottomBar = {
@@ -147,5 +165,47 @@ class MainActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         SecurityManager.endSession()
+    }
+}
+
+
+@Composable
+fun SoberUpTimerAction() {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val soberUpPrefs = context.getSharedPreferences("sober_up", android.content.Context.MODE_PRIVATE)
+
+    var currentTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var networkEndTime by remember { mutableLongStateOf(soberUpPrefs.getLong("end_time", 0L)) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            currentTime = System.currentTimeMillis()
+            networkEndTime = soberUpPrefs.getLong("end_time", 0L)
+            kotlinx.coroutines.delay(1000)
+        }
+    }
+
+    if (networkEndTime > currentTime) {
+        val remaining = networkEndTime - currentTime
+        val m = (remaining / 1000) / 60
+        val s = (remaining / 1000) % 60
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(end = 12.dp)
+        ) {
+            Icon(
+                Icons.Outlined.WifiOff,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 4.dp),
+                tint = MaterialTheme.colorScheme.error
+            )
+            Text(
+                text = "%02d:%02d".format(m, s),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.error,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+            )
+        }
     }
 }

--- a/app/src/main/java/io/github/warleysr/dechainer/screens/tabs/BrowserRestrictionsScreen.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/screens/tabs/BrowserRestrictionsScreen.kt
@@ -1,20 +1,12 @@
 package io.github.warleysr.dechainer.screens.tabs
 
-import androidx.compose.animation.AnimatedVisibility
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
@@ -27,7 +19,6 @@ import io.github.warleysr.dechainer.R
 import io.github.warleysr.dechainer.screens.common.RecoveryConfirmDialog
 import io.github.warleysr.dechainer.security.SecurityManager
 import io.github.warleysr.dechainer.models.AppItem
-import io.github.warleysr.dechainer.models.BlockedList
 import io.github.warleysr.dechainer.viewmodels.AppsViewModel
 import io.github.warleysr.dechainer.viewmodels.BrowserRestrictionsViewModel
 import io.github.warleysr.dechainer.viewmodels.DeviceOwnerViewModel
@@ -39,8 +30,7 @@ fun BrowserRestrictionsScreen(
     appsViewModel: AppsViewModel = viewModel(),
     deviceOwnerViewModel: DeviceOwnerViewModel = viewModel()
 ) {
-    var showEditDialog by remember { mutableStateOf<BlockedList?>(null) }
-    var isCreatingNew by remember { mutableStateOf(false) }
+    var singleSiteInput by remember { mutableStateOf("") }
     var showRestrictionsDialog by remember { mutableStateOf<AppItem?>(null) }
     var pendingAction by remember { mutableStateOf<(() -> Unit)?>(null) }
     var onCancelAction by remember { mutableStateOf<(() -> Unit)?>(null) }
@@ -58,7 +48,7 @@ fun BrowserRestrictionsScreen(
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
-                
+
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Column {
                         viewModel.browsers.forEachIndexed { index, browser ->
@@ -66,7 +56,14 @@ fun BrowserRestrictionsScreen(
                             val notSupported = !manager.supportsRestrictions(browser.packageName)
                             ListItem(
                                 modifier = Modifier.clickable(enabled = !notSupported) {
-                                    showRestrictionsDialog = browser
+                                    showRestrictionsDialog = AppItem(
+                                        name = browser.name,
+                                        packageName = browser.packageName,
+                                        icon = browser.icon,
+                                        isSystem = false,
+                                        isHidden = false,
+                                        isUninstallBlocked = false
+                                    )
                                 },
                                 headlineContent = { Text(browser.name) },
                                 supportingContent = {
@@ -90,12 +87,12 @@ fun BrowserRestrictionsScreen(
                                 },
                                 trailingContent = {
                                     Switch(
-                                        checked = !browser.isSuspended,
+                                        checked = browser.isEnabled,
                                         onCheckedChange = { checked ->
-                                            val wasSuspended = browser.isSuspended
-                                            viewModel.browsers[index] = browser.copy(isSuspended = !checked)
+                                            val wasEnabled = browser.isEnabled
+                                            viewModel.browsers[index] = browser.copy(isEnabled = checked)
                                             onCancelAction = {
-                                                viewModel.browsers[index] = browser.copy(isSuspended = wasSuspended)
+                                                viewModel.browsers[index] = browser.copy(isEnabled = wasEnabled)
                                             }
                                             pendingAction = {
                                                 appsViewModel.suspendApp(browser.packageName, !checked)
@@ -110,53 +107,53 @@ fun BrowserRestrictionsScreen(
                 Spacer(modifier = Modifier.height(24.dp))
             }
 
-            // Blocked Sites Section
             item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        stringResource(R.string.blocked_sites),
-                        style = MaterialTheme.typography.titleLarge
-                    )
-                    IconButton(onClick = { 
-                        isCreatingNew = true
-                        showEditDialog = BlockedList("", "", emptyList())
-                    }) {
-                        Icon(Icons.Default.Add, contentDescription = null)
-                    }
-                }
-            }
-
-            items(viewModel.blockedLists, key = { "url_${it.id}" }) { list ->
-                BlockedListAccordion(
-                    list = list,
-                    onEdit = { 
-                        isCreatingNew = false
-                        showEditDialog = list 
-                    },
-                    onDelete = {
-                        pendingAction = { viewModel.removeList(list.id) }
-                    }
+                Text(
+                    "Block Specific Websites",
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
+                Text(
+                    "Type a site URL to add it. If it already exists, typing it will remove it.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = singleSiteInput,
+                    onValueChange = { singleSiteInput = it },
+                    label = { Text(stringResource(R.string.site_url_hint)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        if (singleSiteInput.isNotBlank()) {
+                            val site = singleSiteInput.trim().lowercase()
+                            val isRemoving = viewModel.hasHiddenSite(site)
 
+                            if (isRemoving) {
+                                pendingAction = {
+                                    viewModel.toggleHiddenSite(site, remove = true)
+                                    Toast.makeText(context, "Site removed", Toast.LENGTH_SHORT).show()
+                                }
+                            } else {
+                                viewModel.toggleHiddenSite(site, remove = false)
+                                Toast.makeText(context, "Site added", Toast.LENGTH_SHORT).show()
+                            }
+                            singleSiteInput = ""
+                        }
+                    }
+                ) { Text("Add / Remove Site") }
+                Spacer(modifier = Modifier.height(24.dp))
+            }
         }
     }
 
     showRestrictionsDialog?.let { browser ->
         AppRestrictionsDialog(
-            app = AppItem(
-                name = browser.name,
-                packageName = browser.packageName,
-                icon = browser.icon,
-                isSystem = false,
-                isHidden = false,
-                isUninstallBlocked = false
-            ),
+            app = browser,
             viewModel = deviceOwnerViewModel,
             onDismiss = { showRestrictionsDialog = null },
             onSave = { restrictions ->
@@ -164,60 +161,6 @@ fun BrowserRestrictionsScreen(
                     deviceOwnerViewModel.setApplicationRestrictions(browser.packageName, restrictions)
                 }
                 showRestrictionsDialog = null
-            }
-        )
-    }
-
-    if (showEditDialog != null) {
-        val currentList = showEditDialog!!
-        var title by remember { mutableStateOf(currentList.title) }
-        var sites by remember { mutableStateOf(currentList.sites.joinToString("\n")) }
-        
-        AlertDialog(
-            onDismissRequest = { showEditDialog = null },
-            title = { 
-                Text(
-                    if (isCreatingNew) {
-                        stringResource(R.string.add_site)
-                    } else currentList.title
-                )
-            },
-            text = {
-                Column {
-                    OutlinedTextField(
-                        value = title,
-                        onValueChange = { title = it },
-                        label = { Text(stringResource(R.string.list_title)) },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = sites,
-                        onValueChange = { sites = it },
-                        label = { Text(stringResource(R.string.sites_lines)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        minLines = 5
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = {
-                    if (title.isNotBlank()) {
-                        pendingAction = { 
-                            viewModel.saveOrUpdateList(
-                                if (isCreatingNew) null else currentList.id,
-                                title,
-                                sites
-                            )
-                        }
-                    }
-                    showEditDialog = null
-                }) { Text(stringResource(R.string.confirm)) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showEditDialog = null }) {
-                    Text(stringResource(R.string.cancel))
-                }
             }
         )
     }
@@ -238,63 +181,12 @@ fun BrowserRestrictionsScreen(
                         true
                     } else false
                 },
-                onDismiss = { 
+                onDismiss = {
                     onCancelAction?.invoke()
                     onCancelAction = null
-                    pendingAction = null 
+                    pendingAction = null
                 }
             )
-        }
-    }
-}
-
-@Composable
-fun BlockedListAccordion(
-    list: BlockedList,
-    onEdit: () -> Unit,
-    onDelete: () -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-    
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = !expanded }
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(list.title, style = MaterialTheme.typography.titleMedium)
-                    Text("${list.sites.size} sites", style = MaterialTheme.typography.labelSmall)
-                }
-                IconButton(onClick = onEdit) {
-                    Icon(Icons.Default.Edit, contentDescription = "")
-                }
-                IconButton(onClick = onDelete) {
-                    Icon(Icons.Default.Delete, contentDescription = "")
-                }
-                Icon(
-                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = null
-                )
-            }
-            
-            AnimatedVisibility(visible = expanded) {
-                Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
-                    HorizontalDivider()
-                    list.sites.forEach { site ->
-                        Text(
-                            site,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.padding(vertical = 4.dp)
-                        )
-                    }
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/io/github/warleysr/dechainer/screens/tabs/ConfigTab.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/screens/tabs/ConfigTab.kt
@@ -1,7 +1,11 @@
 package io.github.warleysr.dechainer.screens.tabs
 
+import androidx.compose.material.icons.outlined.WifiOff
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import android.app.admin.DevicePolicyManager
 import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -57,6 +61,7 @@ fun ConfigTab(viewModel: DeviceOwnerViewModel = viewModel()) {
     var showCancelForcedRemovalDialog by remember { mutableStateOf(false) }
     var showFinishForcedRemovalDialog by remember { mutableStateOf(false) }
     var confirmForcedRemoval by remember { mutableStateOf(false) }
+    var showSoberUpDialog by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -100,13 +105,13 @@ fun ConfigTab(viewModel: DeviceOwnerViewModel = viewModel()) {
             item {
                 ListItem(
                     headlineContent = { Text(stringResource(R.string.dns_settings)) },
-                    supportingContent = { 
+                    supportingContent = {
                         Text( stringResource(R.string.dns_description))
                     },
                     leadingContent = { Icon(Icons.Outlined.Dns, "") },
-                    modifier = Modifier.clickable { 
+                    modifier = Modifier.clickable {
                         dnsErrorRes = null
-                        showDnsDialog = true 
+                        showDnsDialog = true
                     }
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -120,6 +125,43 @@ fun ConfigTab(viewModel: DeviceOwnerViewModel = viewModel()) {
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             }
+
+            // ---  SOBER UP BLOCK ---
+            item {
+                val soberUpPrefs = context.getSharedPreferences("sober_up_prefs", Context.MODE_PRIVATE)
+                var isSoberUpEnabled by remember { mutableStateOf(soberUpPrefs.getBoolean("enabled", false)) }
+
+                ListItem(
+                    headlineContent = { Text("Sober Up Network Block") },
+                    supportingContent = { Text("Disable internet temporarily on sensitive searches") },
+                    leadingContent = { Icon(Icons.Outlined.WifiOff, "") },
+                    trailingContent = {
+                        Switch(
+                            checked = isSoberUpEnabled,
+                            onCheckedChange = { checked ->
+                                if (!checked) {
+                                    pendingAction = {
+                                        isSoberUpEnabled = false
+                                        soberUpPrefs.edit { putBoolean("enabled", false) }
+                                    }
+                                } else {
+                                    // NEW: Ensure Advanced Blocking is on first
+                                    if (!advancedBlocking) {
+                                        Toast.makeText(context, "Please enable Activity Blocker (Advanced Blocking) first.", Toast.LENGTH_LONG).show()
+                                        return@Switch
+                                    }
+                                    isSoberUpEnabled = true
+                                    soberUpPrefs.edit { putBoolean("enabled", true) }
+                                }
+                            }
+                        )
+                    },
+                    modifier = Modifier.clickable { showSoberUpDialog = true }
+                )
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+            // -----------------------------
+
             item {
                 ListItem(
                     headlineContent = { Text(stringResource(R.string.block_torrents)) },
@@ -247,6 +289,47 @@ fun ConfigTab(viewModel: DeviceOwnerViewModel = viewModel()) {
         )
     }
 
+    if (showSoberUpDialog) {
+        val prefs = context.getSharedPreferences("sober_up_prefs", Context.MODE_PRIVATE)
+        val currentDuration = prefs.getInt("duration", 1)
+        var currentWordsSet by remember { mutableStateOf(prefs.getStringSet("sensitive_words", emptySet()) ?: emptySet()) }
+
+        SoberUpDialog(
+            currentDuration = currentDuration,
+            currentWordsSet = currentWordsSet,
+            onDismiss = { showSoberUpDialog = false },
+            onSaveTime = { newTime ->
+                if (newTime < currentDuration) {
+                    pendingAction = {
+                        prefs.edit { putInt("duration", newTime) }
+                        showSoberUpDialog = false
+                        Toast.makeText(context, "Time updated", Toast.LENGTH_SHORT).show()
+                    }
+                } else {
+                    prefs.edit { putInt("duration", newTime) }
+                    showSoberUpDialog = false
+                    Toast.makeText(context, "Time updated", Toast.LENGTH_SHORT).show()
+                }
+            },
+            onToggleWord = { word ->
+                val updatedSet = currentWordsSet.toMutableSet()
+                if (updatedSet.contains(word)) {
+                    pendingAction = {
+                        updatedSet.remove(word)
+                        prefs.edit { putStringSet("sensitive_words", updatedSet) }
+                        currentWordsSet = updatedSet
+                        Toast.makeText(context, "Keyword removed", Toast.LENGTH_SHORT).show()
+                    }
+                } else {
+                    updatedSet.add(word)
+                    prefs.edit { putStringSet("sensitive_words", updatedSet) }
+                    currentWordsSet = updatedSet
+                    Toast.makeText(context, "Keyword added", Toast.LENGTH_SHORT).show()
+                }
+            }
+        )
+    }
+
     if (showStartForcedRemovalDialog) {
         AlertDialog(
             onDismissRequest = { showStartForcedRemovalDialog = false },
@@ -300,7 +383,7 @@ fun ConfigTab(viewModel: DeviceOwnerViewModel = viewModel()) {
 
     if (showFinishForcedRemovalDialog) {
         AlertDialog(
-            onDismissRequest = { 
+            onDismissRequest = {
                 showFinishForcedRemovalDialog = false
                 confirmForcedRemoval = false
             },
@@ -466,8 +549,8 @@ fun DnsSelectionDialog(
         "AdGuard DNS" to "family.adguard-dns.com",
         "CleanBrowsing" to "adult-filter-dns.cleanbrowsing.org"
     )
-    
-    var selectedOption by remember { 
+
+    var selectedOption by remember {
         mutableStateOf(
             when {
                 options.any { it.second == currentDns } -> currentDns
@@ -552,7 +635,7 @@ fun DnsSelectionDialog(
             val canApply = selectedOption != null && (selectedOption != "custom" || isCustomValid) && !isLoading
             TextButton(
                 enabled = canApply,
-                onClick = { 
+                onClick = {
                     val finalHost = when(selectedOption) {
                         "custom" -> customHost
                         else -> selectedOption
@@ -586,8 +669,8 @@ fun LanguageSelectionDialog(
         "en" to "English",
         "pt" to "Português"
     )
-    
-    var selectedOption by remember { 
+
+    var selectedOption by remember {
         mutableStateOf(if (currentLocale.startsWith("pt")) "pt" else "en")
     }
 
@@ -734,3 +817,69 @@ fun ImpulseLockDialog(
     )
 }
 
+@Composable
+fun SoberUpDialog(
+    currentDuration: Int,
+    currentWordsSet: Set<String>,
+    onDismiss: () -> Unit,
+    onSaveTime: (Int) -> Unit,
+    onToggleWord: (String) -> Unit
+) {
+    var durationText by remember { mutableStateOf(currentDuration.toString()) }
+    var singleWordInput by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Sober Up Settings") },
+        text = {
+            Column {
+                // TIME SETTING
+                Text("Block Duration (minutes)", fontWeight = FontWeight.Bold)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedTextField(
+                        value = durationText,
+                        onValueChange = { if (it.isEmpty() || it.all { char -> char.isDigit() }) durationText = it },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f),
+                        singleLine = true
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = {
+                        val newTime = durationText.toIntOrNull() ?: 1
+                        onSaveTime(newTime)
+                    }) { Text("Save Time") }
+                }
+
+                Spacer(Modifier.height(24.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(24.dp))
+
+                // HIDDEN KEYWORD MANAGEMENT
+                Text("Manage Hidden Keywords", fontWeight = FontWeight.Bold)
+                Text("Type a keyword to add it. If it already exists, typing it will remove it.", style = MaterialTheme.typography.labelSmall)
+                Spacer(Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = singleWordInput,
+                    onValueChange = { singleWordInput = it },
+                    label = { Text("Enter a single keyword") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        if (singleWordInput.isNotBlank()) {
+                            onToggleWord(singleWordInput.trim().lowercase())
+                            singleWordInput = ""
+                        }
+                    }
+                ) { Text("Add / Remove Keyword") }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.close)) }
+        }
+    )
+}

--- a/app/src/main/java/io/github/warleysr/dechainer/utils/NetworkBlockManager.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/utils/NetworkBlockManager.kt
@@ -1,0 +1,109 @@
+package io.github.warleysr.dechainer.utils
+
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.net.ProxyInfo
+import android.net.wifi.WifiManager
+import android.os.Handler
+import android.os.Looper
+import android.os.UserManager
+import androidx.core.content.edit
+import io.github.warleysr.dechainer.DechainerDeviceAdminReceiver
+
+object NetworkBlockManager {
+    private val handler = Handler(Looper.getMainLooper())
+
+    fun triggerBlock(context: Context) {
+        val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+
+        val prefs = context.getSharedPreferences("sober_up_prefs", Context.MODE_PRIVATE)
+        val durationMin = prefs.getInt("duration", 1)
+        val durationMs = durationMin * 60_000L
+
+        // 1. Native Wi-Fi Toggle (Device Owners are exempt from Android 10+ restrictions)
+        try {
+            val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            wifiManager.isWifiEnabled = false
+        } catch (e: Exception) { e.printStackTrace() }
+
+        // 2. Shizuku Fallback for Mobile Data (Fails silently if Shizuku is not running)
+        try {
+            ShizukuRunner.command("svc wifi disable && svc data disable", object : ShizukuRunner.CommandResultListener {})
+        } catch (e: Exception) { e.printStackTrace() }
+
+        if (dpm.isAdminActive(admin)) {
+            // 3. The Bulletproof Kill Switch: Route all traffic to a dead port
+            try {
+                val proxy = ProxyInfo.buildDirectProxy("127.0.0.1", 8080)
+                dpm.setRecommendedGlobalProxy(admin, proxy)
+            } catch (e: Exception) { e.printStackTrace() }
+
+            // 4. Lock network configuration screens
+            dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_WIFI)
+            dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_MOBILE_NETWORKS)
+            dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_TETHERING)
+        }
+
+        val endTime = System.currentTimeMillis() + durationMs
+        context.getSharedPreferences("sober_up", Context.MODE_PRIVATE).edit { putLong("end_time", endTime) }
+
+        scheduleRestore(context, durationMs)
+    }
+
+    fun checkAndRestoreOnBoot(context: Context) {
+        val endTime = context.getSharedPreferences("sober_up", Context.MODE_PRIVATE).getLong("end_time", 0L)
+        val remaining = endTime - System.currentTimeMillis()
+
+        if (remaining > 0) {
+            val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+            val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+
+            try {
+                val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+                wifiManager.isWifiEnabled = false
+            } catch (e: Exception) {}
+
+            try {
+                ShizukuRunner.command("svc wifi disable && svc data disable", object : ShizukuRunner.CommandResultListener {})
+            } catch (e: Exception) {}
+
+            if (dpm.isAdminActive(admin)) {
+                try {
+                    val proxy = ProxyInfo.buildDirectProxy("127.0.0.1", 8080)
+                    dpm.setRecommendedGlobalProxy(admin, proxy)
+                } catch (e: Exception) {}
+
+                dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_WIFI)
+                dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_MOBILE_NETWORKS)
+                dpm.addUserRestriction(admin, UserManager.DISALLOW_CONFIG_TETHERING)
+            }
+            scheduleRestore(context, remaining)
+        } else if (endTime > 0) {
+            restoreNetwork(context)
+        }
+    }
+
+    private fun scheduleRestore(context: Context, delay: Long) {
+        handler.removeCallbacksAndMessages(null)
+        handler.postDelayed({ restoreNetwork(context) }, delay)
+    }
+
+    private fun restoreNetwork(context: Context) {
+        val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(context, DechainerDeviceAdminReceiver::class.java)
+
+        if (dpm.isAdminActive(admin)) {
+            // Clear the dead proxy, restoring internet
+            try {
+                dpm.setRecommendedGlobalProxy(admin, null)
+            } catch (e: Exception) {}
+
+            dpm.clearUserRestriction(admin, UserManager.DISALLOW_CONFIG_WIFI)
+            dpm.clearUserRestriction(admin, UserManager.DISALLOW_CONFIG_MOBILE_NETWORKS)
+            dpm.clearUserRestriction(admin, UserManager.DISALLOW_CONFIG_TETHERING)
+        }
+        context.getSharedPreferences("sober_up", Context.MODE_PRIVATE).edit { remove("end_time") }
+    }
+}

--- a/app/src/main/java/io/github/warleysr/dechainer/viewmodels/BrowserRestrictionsViewModel.kt
+++ b/app/src/main/java/io/github/warleysr/dechainer/viewmodels/BrowserRestrictionsViewModel.kt
@@ -1,38 +1,64 @@
 package io.github.warleysr.dechainer.viewmodels
 
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
 import android.content.Context
+import android.graphics.drawable.Drawable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import io.github.warleysr.dechainer.DechainerApplication
 import androidx.core.content.edit
 import io.github.warleysr.dechainer.BrowserRestrictionsManager
-import io.github.warleysr.dechainer.data.AppRepository
-import io.github.warleysr.dechainer.models.AppItem
-import io.github.warleysr.dechainer.models.BlockedList
 import org.json.JSONArray
 import org.json.JSONObject
 
+data class BrowserApp(
+    val name: String,
+    val packageName: String,
+    val icon: Drawable,
+    var isEnabled: Boolean
+)
+
+data class BlockedList(
+    val id: String,
+    val title: String,
+    val sites: List<String>
+)
+
 class BrowserRestrictionsViewModel : ViewModel() {
     private val context = DechainerApplication.getInstance()
+    private val packageManager = context.packageManager
+    private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+    private val adminName = ComponentName(context, io.github.warleysr.dechainer.DechainerDeviceAdminReceiver::class.java)
     private val manager = BrowserRestrictionsManager(context)
 
-    var browsers = mutableStateListOf<AppItem>()
+    var browsers = mutableStateListOf<BrowserApp>()
         private set
 
-    var blockedLists = mutableStateListOf<BlockedList>()
-        private set
+    private var blockedLists = mutableStateListOf<BlockedList>()
 
     init {
         loadBrowsers()
         loadBlockedLists()
     }
 
-    fun loadBrowsers() {
+    private fun loadBrowsers() {
         val possibleBrowsers = manager.getPossibleBrowsers()
-        val browserPackages = possibleBrowsers.map { it.activityInfo.packageName }.toSet()
-        
         browsers.clear()
-        browsers.addAll(AppRepository.getApps().filter { it.packageName in browserPackages })
+        possibleBrowsers.forEach { info ->
+            val packageName = info.activityInfo.packageName
+            val isSuspended = try {
+                dpm.isPackageSuspended(adminName, packageName)
+            } catch (_: Exception) { false }
+            browsers.add(
+                BrowserApp(
+                    name = info.loadLabel(packageManager).toString(),
+                    packageName = packageName,
+                    icon = info.loadIcon(packageManager),
+                    isEnabled = !isSuspended
+                )
+            )
+        }
     }
 
     private fun loadBlockedLists() {
@@ -61,29 +87,6 @@ class BrowserRestrictionsViewModel : ViewModel() {
         } catch (e: Exception) { e.printStackTrace() }
     }
 
-    fun saveOrUpdateList(id: String?, title: String, sitesString: String) {
-        val sites = sitesString.lines().filter { it.isNotBlank() }.map { it.trim() }
-        val newListId = id ?: System.currentTimeMillis().toString()
-        val newList = BlockedList(newListId, title, sites)
-
-        val index = blockedLists.indexOfFirst { it.id == newListId }
-        if (index != -1) {
-            blockedLists[index] = newList
-        } else {
-            blockedLists.add(newList)
-        }
-
-        saveBlockedLists()
-        manager.applyRestrictions()
-    }
-
-    fun removeList(id: String) {
-        if (blockedLists.removeIf { it.id == id }) {
-            saveBlockedLists()
-            manager.applyRestrictions()
-        }
-    }
-
     private fun saveBlockedLists() {
         val prefs = context.getSharedPreferences("browser_prefs", Context.MODE_PRIVATE)
         val array = JSONArray()
@@ -96,5 +99,30 @@ class BrowserRestrictionsViewModel : ViewModel() {
             array.put(obj)
         }
         prefs.edit { putString("blocked_lists_json", array.toString()) }
+    }
+
+    fun hasHiddenSite(site: String): Boolean {
+        val list = blockedLists.find { it.id == "hidden_list" }
+        return list?.sites?.contains(site) == true
+    }
+
+    fun toggleHiddenSite(site: String, remove: Boolean) {
+        val listIndex = blockedLists.indexOfFirst { it.id == "hidden_list" }
+        val currentSites = if (listIndex != -1) blockedLists[listIndex].sites.toMutableList() else mutableListOf()
+
+        if (remove) {
+            currentSites.remove(site)
+        } else {
+            if (!currentSites.contains(site)) currentSites.add(site)
+        }
+
+        val newList = BlockedList("hidden_list", "Hidden Sites", currentSites)
+        if (listIndex != -1) {
+            blockedLists[listIndex] = newList
+        } else {
+            blockedLists.add(newList)
+        }
+        saveBlockedLists()
+        manager.applyRestrictions()
     }
 }

--- a/app/src/main/res/raw/block_keywords_expanded.txt
+++ b/app/src/main/res/raw/block_keywords_expanded.txt
@@ -1,0 +1,1272 @@
+Porn
+XXX
+Nude
+Webcam sex
+Blue film
+Roleplay adult
+Sex
+Adult videos
+Adult only
+18+
+Hardcore
+Erotic
+OnlyFans
+PornHub
+Adult anime
+Dominant
+Submissive
+Rape
+BDSM
+Webcam models
+Hentai
+Strip chat
+Escort services
+Live cams
+Topless
+Fetish
+Underwear
+Swimsuits
+Sex chat
+Camgirl
+Pornhub premium
+Erotica
+Adult forum
+Nudity app
+adult film
+adult movie
+adult video
+anal
+ass
+bara
+barely legal
+bestiality
+bisexual
+bitch
+bondage
+boob
+boobs
+boobies
+boobys
+bound & gagged
+bound and gagged
+breast
+breasts
+bukkake
+butt
+cameltoe
+creampie
+cock
+condom
+cuck-old
+cuckold
+cum
+cum-shot
+cunt
+deep thraot
+deep throat
+deap throat
+deep thraoting
+deep throating
+deap throating
+deep-thraot
+deep-throat
+deap-throat
+deep-thraoting
+deep-throating
+deap-throating
+deepthraot
+deepthroat
+deapthroat
+deepthraoting
+deepthroating
+deapthroating
+dick
+emetophilia
+erection
+erections
+escort
+facesitting
+facial
+felching
+femdon
+fisting
+futanari
+fuck
+fucking
+fucked
+fucks
+fucker
+gapping
+gay
+gentlemens club
+gloryhole
+glory hole
+gonzo
+gore
+guro
+hardon
+hard-on
+hermaphrodite
+hidden camera
+hump
+humped
+humping
+hustler
+incest
+jerking off
+kinky
+lesbian
+lolicon
+mature
+mens club
+menstrual
+menstral
+menstraul
+milking
+naked
+naughty
+orgasm
+orgy
+orgie
+pearl necklace
+pegging
+penis
+penetration
+playboy
+playguy
+playgirl
+pornagraphy
+pov
+pregnant
+preggo
+pubic
+pussy
+rimjob
+scat
+semen
+sexual
+sexy
+sexting
+skank
+slut
+snuff
+snuf
+sperm
+squirt
+swapping
+transman
+transsexual
+transgender
+threesome
+tube8
+twink
+upskirt
+vagina
+virgin
+whore
+wore
+yaoi
+yif
+yiff
+yiffy
+yuri
+youporn
+adult content
+adult content site
+adult content website
+adult entertainment
+adult entertainment site
+adult entertainment website
+adult material
+adult media
+adult movies
+adult site
+adult sites
+adult website
+adult websites
+adult streaming
+adult livestream
+adult livestreams
+adult live stream
+adult live streams
+adult cam
+adult cams
+adult webcam
+adult webcams
+adult chat
+adult chats
+adult dating
+adult dating site
+adult dating sites
+adult hookup
+adult hookups
+adult community
+adult communities
+explicit content
+explicit video
+explicit videos
+explicit photos
+explicit images
+explicit picture
+explicit pictures
+sex video
+sex videos
+sex movie
+sex movies
+sex tape
+sex tapes
+sex film
+sex films
+sex scene
+sex scenes
+sex clip
+sex clips
+sex website
+sex websites
+sex site
+sex sites
+sex streaming
+sex stream
+sex streams
+sex live
+sex live stream
+sex livestream
+sex cam
+sex cams
+sex webcam
+sex webcams
+sex chats
+sex show
+sex shows
+sex worker
+sex workers
+sex work
+sexual content
+sexual video
+sexual videos
+sexual image
+sexual images
+sexual picture
+sexual pictures
+sexual photos
+sexual photography
+sexual scene
+sexual scenes
+sexual material
+sexual media
+sexual act
+sexual acts
+sexual activity
+sexual activities
+sexual intercourse
+sexual intercourse video
+pornographic
+pornographic content
+pornographic video
+pornographic videos
+pornographic image
+pornographic images
+pornographic photos
+pornographic website
+pornographic websites
+pornographic material
+pornography
+pornographies
+porn video
+porn videos
+porn movie
+porn movies
+porn film
+porn films
+porn clip
+porn clips
+porn site
+porn sites
+porn website
+porn websites
+porn streaming
+porn stream
+porn streams
+porn live
+porn livestream
+porn live stream
+porn cam
+porn cams
+porn webcam
+porn webcams
+porn chat
+porn chats
+porn star
+pornstars
+porn stars
+porn actress
+porn actresses
+porn actor
+porn actors
+porn model
+porn models
+pornographic actress
+pornographic actor
+pornographic model
+adult actress
+adult actor
+adult model
+adult models
+xxx video
+xxx videos
+xxx movie
+xxx movies
+xxx film
+xxx films
+xxx clip
+xxx clips
+xxx site
+xxx sites
+xxx website
+xxx websites
+xxx streaming
+xxx stream
+xxx streams
+xxx cam
+xxx cams
+xxx webcam
+xxx webcams
+xxx chat
+xxx chats
+xxx content
+xxx images
+xxx photos
+x rated
+x-rated
+xrated
+triple x
+triple-x
+nsfw
+nsfw content
+nsfw video
+nsfw videos
+nsfw image
+nsfw images
+nsfw photos
+nsfw site
+nsfw sites
+not safe for work
+18 plus
+18plus
+adults only
+mature content
+mature videos
+mature video
+mature site
+mature sites
+erotic content
+erotic video
+erotic videos
+erotic image
+erotic images
+erotic photos
+erotic photography
+erotic story
+erotic stories
+erotic fiction
+erotic art
+erotic arts
+sensual content
+sensual video
+sensual videos
+sensual photos
+sensual photography
+nudes
+nudity
+naked women
+naked woman
+naked men
+naked man
+naked girl
+naked girls
+naked boy
+naked boys
+naked celebrity
+naked celebrities
+nude women
+nude woman
+nude men
+nude man
+nude girl
+nude girls
+nude celebrity
+nude celebrities
+nude photo
+nude photos
+nude picture
+nude pictures
+nude image
+nude images
+nude video
+nude videos
+nude model
+nude models
+nude art
+topless women
+topless woman
+topless men
+topless girl
+topless girls
+topless photo
+topless photos
+topless video
+topless videos
+bottomless
+bare breasts
+bare breast
+bare chest
+bare body
+bare skin
+boob job
+boob jobs
+breast job
+breast jobs
+cleavage
+deep cleavage
+areola
+nipples
+nipple
+nipple slip
+wardrobe malfunction
+camel toe
+pussies
+vaginas
+vaginal
+vulva
+clitoris
+clitoral
+cervix
+labia
+penises
+penile
+dicks
+cocks
+balls
+testicles
+scrotum
+cumming
+cumshot
+cum shot
+cumshots
+cum shots
+facials
+cream pie
+creampies
+creampie video
+squirting
+ejaculation
+ejaculate
+ejaculating
+orgasms
+orgies
+masturbate
+masturbation
+masturbating
+masturbator
+masturbators
+jerk off
+jacking off
+handjob
+hand job
+hand jobs
+blowjob
+blow job
+blow jobs
+throatfucking
+throat fucking
+throat fuck
+throatfuck
+facial cum
+cum on face
+cum on her face
+cum on him
+cum in mouth
+cum in her mouth
+cum in mouth video
+analsex
+anal sex
+anal video
+anal videos
+anal porn
+analporn
+anal penetration
+anal penetration video
+anal scene
+anal scenes
+anal play
+anal toys
+rim job
+rimming
+asses
+asshole
+ass holes
+butts
+butt plug
+butt plugs
+ass plug
+ass plugs
+fist
+fistfuck
+fist fucking
+gaping
+gaping asshole
+gaping ass
+domination
+dominatrix
+domme
+dominant woman
+submission
+submissive woman
+submissive man
+switch bdsm
+spanking
+spank
+spanks
+spanked
+discipline bdsm
+sadism
+sadist
+masochism
+masochist
+s&m
+s and m
+sadomasochism
+leather bdsm
+latex bdsm
+collar bdsm
+choker bdsm
+slave bdsm
+sex slave
+sluts
+slutty
+whores
+whoring
+hooker
+hookers
+escorts
+escort girl
+escort girls
+escort service
+prostitute
+prostitutes
+prostitution
+brothel
+brothels
+red light district
+strip club
+strip clubs
+stripper
+strippers
+striptease
+strip tease
+pole dance
+pole dancing
+lap dance
+lap dancing
+gentlemen's club
+strapon
+strap-on
+strap on
+dildo
+dildos
+vibrator
+vibrators
+sex toy
+sex toys
+adult toy
+adult toys
+anal plug
+cock ring
+penis ring
+love doll
+sex doll
+sex dolls
+inflatable doll
+pocket pussy
+fleshlight
+masturbation sleeve
+gag
+gagged
+gagging
+ball gag
+mouth gag
+blindfold bdsm
+handcuffs bdsm
+restraints bdsm
+restraint
+rope bondage
+shibari
+hentaivideos
+hentai video
+hentai videos
+hentai porn
+hentai manga
+hentai anime
+hentai doujin
+doujinshi adult
+doujin adult
+ecchi
+furry porn
+furry sex
+futa
+futa porn
+loli porn
+shotacon
+shota porn
+milf
+milfs
+cougar
+cougars
+mature woman
+mature women
+mature man
+mature men
+gilf
+dilf
+stepmom porn
+stepmom
+step mom
+stepmother
+stepmother porn
+stepdad porn
+stepdad
+step dad
+stepsister porn
+step sister
+stepsis
+stepbrother porn
+step brother
+stepbro
+sister porn
+brother porn
+incest porn
+family porn
+teacher porn
+student teacher porn
+schoolgirl porn
+schoolboy porn
+college porn
+cheating wife porn
+cheating husband porn
+wife sharing
+hotwife
+cuck
+cuckold porn
+cuckoldry
+cuckquean
+threeway
+three way
+foursome
+orgasm denial
+edging porn
+edging
+denial bdsm
+roleplay porn
+adult roleplay
+role play porn
+sex roleplay
+webcam porn
+webcam model
+camgirls
+camboy
+camboys
+cam girl
+cam girls
+cam boy
+cam boys
+live cam
+live sex
+live sex show
+sex show live
+private show
+private shows
+cam show
+cam shows
+stripchat
+sex chat room
+porn chat room
+adult chat room
+phone sex
+phone sex chat
+cybersex
+cyber sex
+sexting nude
+nude exchange
+send nudes
+trade nudes
+sex pics
+sex picture
+sex pictures
+sex photos
+private pics
+private photos
+leaked nude
+leaked nudes
+leaked sex tape
+sex tape leak
+celebrity sex tape
+celebrity nude
+celebrity nudes
+revenge porn
+nonconsensual porn
+non consensual porn
+deepfake porn
+deepfake nude
+deepfake nudes
+ai porn
+ai nude
+ai nudes
+porn deepfake
+porn deepfakes
+sexual deepfake
+sexual deepfakes
+hidden cam
+voyeur
+voyeurism
+up skirt
+downblouse
+down blouse
+panty
+panties
+lingerie
+fetishes
+fetish porn
+feet porn
+foot fetish
+footjob
+foot job
+leg fetish
+breast fetish
+boob fetish
+panty fetish
+underwear fetish
+latex fetish
+leather fetish
+uniform fetish
+cosplay porn
+costume porn
+roleplay
+adult cosplay
+porn cosplay
+public sex
+outdoor sex
+voyeur porn
+pee fetish
+piss fetish
+watersports
+water sports
+scat porn
+poop fetish
+coprophilia
+urophilia
+vomit fetish
+zoophilia
+animal porn
+beastiality
+gore porn
+snuff film
+snuff movie
+hardcore porn
+hard core porn
+softcore
+soft core porn
+gonzo porn
+amateur porn
+amateur sex
+homemade porn
+home made porn
+homemade sex
+home video porn
+user generated porn
+user-generated porn
+real amateur porn
+porn compilation
+porn compilations
+porn collection
+porn collections
+free porn
+free porn videos
+watch porn
+watch porn free
+free xxx
+free xxx videos
+free sex videos
+free adult videos
+download porn
+porn download
+porn downloads
+porn torrent
+porn torrents
+xnxx
+xvideos
+xhamster
+xhamster live
+redtube
+you porn
+spankbang
+eporner
+beeg
+beeg free
+pornhd
+pornhd3x
+tnaflix
+youjizz
+drtuber
+nuvid
+porn.com
+sex.com
+xvideos2
+xhamsterlive
+xhamster live cam
+chaturbate
+livejasmin
+myfreecams
+camsoda
+bongacams
+flirt4free
+cam4
+cam4free
+streamate
+imlive
+jerkmate
+camcontacts
+adultwork
+fansly
+manyvids
+pornbox
+pornone
+pornoxo
+porn300
+pornpics
+pornpics.com
+pornmd
+pornhub.com
+xnxx.com
+xvideos.com
+xhamster.com
+redtube.com
+youporn.com
+tube8.com
+spankbang.com
+eporner.com
+beeg.com
+tnaflix.com
+youjizz.com
+drtuber.com
+nuvid.com
+chaturbate.com
+stripchat.com
+livejasmin.com
+myfreecams.com
+camsoda.com
+bongacams.com
+cam4.com
+imlive.com
+onlyfans.com
+fansly.com
+manyvids.com
+pornmd.com
+pornolab
+pornolab.net
+porn555
+pornrewind
+pornpros
+pornpros network
+realitykings
+brazzers
+bangbros
+naughtyamerica
+evilangel
+teamskeet
+digitalplayground
+mofos
+fakehub
+twistys
+babesandbitches
+mylf
+blacked
+tushy
+deeper
+vixen
+passion hd
+reality junkies
+wicked pictures
+wicked
+private media
+private.com
+dorcel
+x-art
+metart
+metart network
+penthouse
+girlfriendsfilms
+girlfriends films
+milfed
+vivid
+vivid entertainment
+redgifs
+xhamster porn
+xvideos porn
+pornhub porn
+xnxx porn
+youporn porn
+reddit porn
+nsfw reddit
+porn subreddit
+nsfw subreddit
+nsfw gifs
+porn gif
+porn gifs
+sex gif
+sex gifs
+porn manga
+porn comic
+porn comics
+adult manga
+adult comics
+doujin
+doujinshi
+rule34
+rule 34
+r34
+rule34 porn
+rule34.xxx
+danbooru nsfw
+e621
+e621 furry
+gelbooru
+porn art
+adult art
+adult illustration
+explicit art
+sexual art
+nsfw art
+nsfw anime
+porn anime
+anime porn
+hentai doujinshi
+yaoi hentai
+yuri hentai
+gay porn
+gay sex
+gay porn video
+gay porn videos
+lesbian porn
+lesbian sex
+lesbian video
+lesbian videos
+bisexual porn
+bi porn
+trans porn
+transgender porn
+trans porn video
+shemale porn
+transsexual porn
+intersex porn
+futa hentai
+futanari hentai
+twink porn
+bear porn
+gay bear
+muscle porn
+men porn
+male porn
+female porn
+straight porn
+hetero porn
+queer porn
+same sex porn
+same-sex porn
+sex with men
+sex with women
+porn for men
+porn for women
+porn for couples
+couples porn
+swingers
+swinger porn
+swinging couples
+wife swap porn
+wife swapping
+partner swapping
+group sex
+groupsex
+gangbang
+gang bang
+double penetration
+dp porn
+double penetrated
+double penetration porn
+triple penetration
+multiple penetration
+bbc porn
+big black cock
+bbc gangbang
+big tits
+big boobs
+large breasts
+huge tits
+huge boobs
+busty
+buxom
+teen porn
+teen sex
+teen videos
+teen xxx
+barely-legal
+young-looking porn
+college girl porn
+college boy porn
+mature porn
+milf porn
+gilf porn
+mom porn
+mommy porn
+daddy porn
+stepsister
+stepdaughter porn
+stepdaughter
+stepfather porn
+stepfather
+stepbrother
+housewife porn
+office porn
+secretary porn
+nurse porn
+doctor porn
+maid porn
+babysitter porn
+massage porn
+masseuse porn
+professor porn
+police porn
+cop porn
+firefighter porn
+prison porn
+uniform porn
+sex worker porn
+prostitute porn
+escort porn
+hooker porn
+street prostitution
+camgirl porn
+camgirl live
+camgirl show
+onlyfans leak
+onlyfans leaks
+fansly leak
+fansly leaks
+premium content leak
+premium porn
+paid porn
+porn subscription
+adult subscription
+adult creator
+adult creator platform
+content creator porn
+creator porn
+leaked content
+leaked videos
+leaked photos
+leaked pictures
+nude leak
+nude leaks
+private video leak
+private videos
+sex leak
+sex leaks
+nude scandal
+sex scandal
+explicit leak
+explicit leaks
+18 year old porn
+18yo porn
+18+ porn
+hookup sex
+motherfucker
+mother fucker
+fuckable
+fucking video
+fucking videos
+fuck video
+fuck videos
+sexfuck
+fuck sex
+anal fuck
+pornfuck
+raw sex
+raw porn
+unprotected sex
+bareback
+bareback porn
+bareback sex
+cream-pie
+face sitting
+face-sitting
+titfuck
+tit fuck
+boobjob
+breastfeeding fetish
+lactation fetish
+milk fetish
+piss
+pissing
+golden shower
+golden showers
+watersports porn
+shit fetish
+shit porn
+ass worship
+cock worship
+pussy worship
+armpit fetish
+armpit porn
+smothering fetish
+choking fetish
+choke
+choking sex
+breath play
+breathplay
+hypno porn
+hypnosis porn
+hypnotic sex
+trance porn
+public blowjob
+public sex video
+amateur blowjob
+amateur handjob
+amateur anal
+amateur gangbang
+homemade blowjob
+homemade handjob
+homemade sex tape
+sex tutorial porn
+how to masturbate
+how to have sex
+how to give blowjob
+how to anal
+porn tutorial
+adult search
+porn search
+porn keywords
+sex keywords
+xxx search
+nsfw search
+justporn
+ixxx
+pornhat
+sexvid
+اباحي
+إباحي
+إباحية
+محتوى إباحي
+موقع إباحي
+مواقع إباحية
+فيديو إباحي
+فيديوهات إباحية
+صور إباحية
+صورة إباحية
+جنس
+جنسية
+ممارسة الجنس
+فيديو جنس
+فيديوهات جنس
+صور عارية
+صورة عارية
+عاري
+عارية
+عراة
+تعري
+تعريه
+محتوى جنسي
+محتوى جنسي صريح
+محتوى للبالغين
+للبالغين
+سكس
+جنس مثلي
+جنس سحاقي
+سحاق
+مثلي الجنس
+دعارة
+بغاء
+عاهرة
+عاهرات
+مومس
+مومسات
+بورن
+بورنو
+بورنوجرافيا
+إباحية جنسية
+مواقع بورن
+فيديو بورن
+فيديوهات بورن
+صور بورن
+ويب كام جنسي
+كاميرا جنسية
+محادثة جنسية
+شات جنسي
+استمناء
+عادة سرية
+إثارة جنسية
+إثارة
+نشوة جنسية
+نزو
+قذف
+مني
+عضو ذكري
+قضيب
+مهبل
+فرج
+ثدي
+أثداء
+حلمات
+مؤخرة
+شرج
+جنس شرجي
+مداعبة جنسية
+علاقة جنسية
+علاقات جنسية
+عري
+عارية الصدر
+فيديو عاري
+فيديوهات عارية
+هنتاي
+هنتاي عربي
+أنمي إباحي
+أنمي جنسي
+مانجا إباحية
+مانجا جنسية
+بث جنسي مباشر
+بث مباشر إباحي
+ويب كام
+كام جيرل
+فتيات الكام
+فيديوهات للبالغين
+مقاطع جنسية
+مقاطع إباحية
+أفلام إباحية
+فيلم إباحي
+أفلام للبالغين
+ممثلة إباحية
+ممثل إباحي
+موديل إباحي
+عارضات إباحية
+مواقع تعارف جنسية
+مواعدة جنسية
+دعارة إلكترونية
+محتوى صريح
+صور صريحة
+فيديو صريح
+فيديوهات صريحة
+تسريب صور عارية
+تسريب فيديوهات
+فضيحة جنسية
+شريط جنسي
+تسريب جنسي
+صور خاصة مسربة
+فيديو خاص مسرب


### PR DESCRIPTION



#### **1. Bulletproof "Sober Up" Network Blocker**

* **Triple-Layer Network Lock (`NetworkBlockManager`):** Implemented a tamper-proof network lock that cannot be bypassed via Quick Settings.
* **Dead Global Proxy:** Uses Device Owner privileges to route all traffic to `127.0.0.1:8080`.
* **Native Wi-Fi Toggle:** Natively disables Wi-Fi (exempt from Android 10+ restrictions due to Device Owner status).
* **Shizuku Fallback:** Executes `svc wifi disable && svc data disable` if Shizuku is running.
* **Settings Lock:** Applies `DISALLOW_CONFIG_WIFI`, `DISALLOW_CONFIG_MOBILE_NETWORKS`, and `DISALLOW_CONFIG_TETHERING`.


* **Reboot Persistence:** The lock state and timer are saved to `SharedPreferences`. If the device is rebooted during a penalty, the restrictions are immediately reapplied on boot.

#### **2. Smart Search Detection & Tab Closure**

* **Action-Based Trigger:** The `DechainerAccessibilityService` now monitors the `isTyping` focus state. It waits until the user finishes typing and submits the search (losing focus on the `EditText` node) before scanning the text. This prevents the app from acting as a passive blocker on safe paragraphs of text.
* **Tab Closure:** Upon detecting a forbidden search, the service fires `GLOBAL_ACTION_BACK` twice to instantly close the keyboard and exit the search results page before launching the `BlockedWordActivity`.


#### **3. "Blind Input" for Keywords & Sites**

* **Hidden Lists:** Refactored `BrowserRestrictionsScreen` and the Sober Up dialog to remove visible lists of blocked items (e.g., the accordion UI).
* **Blind Toggle System:** Users can add new sites/keywords freely. However, to remove an item, they must blindly type the exact string and authenticate using the **16-character Recovery Key**, thereby preventing easy circumvention during urges.
* **UI Feedback:** Added Toasts to clearly notify the user when a keyword/site is successfully added or removed.

#### **4. Config & UI Updates**

* Added the "Sober Up Network Block" Switch to `ConfigTab`.
* Added a validation check to ensure "Activity Blocker" (Advanced Blocking) is enabled before allowing the Sober Up feature to be turned on.